### PR TITLE
chore(doc): Change api doc url to the latest available

### DIFF
--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -12,7 +12,7 @@ info:
     url: images/logo_bonitasoft_white.png
     backgroundColor: "#003355"
     altText: "Bonita API"
-    href: "https://documentation.bonitasoft.com/bonita/7.11/_rest-api"
+    href: "https://documentation.bonitasoft.com/bonita/latest/rest-api-overview"
 servers:
   - url: 'https://localhost:8080/bonita'
   - url: 'https://bonita.localhost/bonita'


### PR DESCRIPTION
Changed url to : https://documentation.bonitasoft.com/bonita/latest/rest-api-overview

Should close https://github.com/bonitasoft/bonita-openapi/issues/14 