### PR TITLE
fix(state): add missing task states

### DIFF
--- a/openapi/components/schemas/AbstractTask.yaml
+++ b/openapi/components/schemas/AbstractTask.yaml
@@ -21,7 +21,7 @@ properties:
   state:
     description: the current state of the task
     type: string
-    enum: [ ready,completed,failed ]
+    enum: [ initializing,ready,executing,completing,waiting,completed,failed,skipped,cancelled,aborted ]
   reached_state_date:
     description: the date ('yyyy-MM-dd HH:mm:ss.SSS') when this task reached the current state for example '2014-10-17 16:05:42.626'
     type: string


### PR DESCRIPTION
Bases on `org.bonitasoft.engine.bpm.flownode.ActivityStates`
Causing response deserialization issues when unknown states are set when using the bonita-java-client.