### PR TITLE
feat(bdm): Make bdm requests return Objects instead of BusinessData

### DIFF
--- a/openapi/components/schemas/AnyValue.yaml
+++ b/openapi/components/schemas/AnyValue.yaml
@@ -1,0 +1,2 @@
+nullable: true
+description: Can be any value - string, number, boolean, array or object or null depending on your query.

--- a/openapi/paths/API@bdm@businessData@{businessDataType}.yaml
+++ b/openapi/paths/API@bdm@businessData@{businessDataType}.yaml
@@ -56,7 +56,7 @@ get:
           schema:
             type: array
             items:
-              $ref: '../components/schemas/BusinessData.yaml'
+              $ref: '../components/schemas/AnyValue.yaml'
     '401':
       $ref: '../components/responses/Unauthorized.yaml'
     '403':


### PR DESCRIPTION
Introduced a new schema : AnyValue based on the documentation https://swagger.io/docs/specification/data-models/data-types/#object
When executing named query the return type can be anything and cannot be defined in the openapi spec. Making it always return BusinessData breaks the call when the query returns scalars or simple types.

We should use Object instead and let the user deals with the query result type.