### PR TITLE
feat(bpm): Fix definition that was breaking code generation

### DIFF
--- a/openapi/components/schemas/AnyValue.yaml
+++ b/openapi/components/schemas/AnyValue.yaml
@@ -1,0 +1,2 @@
+nullable: true
+description: Can be any value - string, number, boolean, array or object or null depending on your query.

--- a/openapi/components/schemas/UpdateProcessConnectorByProcessIdRequest.yaml
+++ b/openapi/components/schemas/UpdateProcessConnectorByProcessIdRequest.yaml
@@ -1,0 +1,11 @@
+type: object
+properties:
+  id:
+    description: Id of the process for which to update the connector, combined with connector name and version separated by slashes (x/y/z)
+    type: string
+  implementation:
+    description: Previously uploaded temp file name of the updated version of the connector (returned by the  [upload file api](#operation/uploadFile))
+    type: string
+example:
+  id: "8491796209115952722/scripting-groovy-script/1.0.1"
+  implementation: "tmp_7006630415905915150.zip"

--- a/openapi/paths/API@bdm@businessData@{businessDataType}.yaml
+++ b/openapi/paths/API@bdm@businessData@{businessDataType}.yaml
@@ -56,7 +56,7 @@ get:
           schema:
             type: array
             items:
-              $ref: '../components/schemas/BusinessData.yaml'
+              $ref: '../components/schemas/AnyValue.yaml'
     '401':
       $ref: '../components/responses/Unauthorized.yaml'
     '403':

--- a/openapi/paths/API@bpm@processConnector@{id}@{connectorImplId}@{connectorImplVersion}.yaml
+++ b/openapi/paths/API@bpm@processConnector@{id}@{connectorImplId}@{connectorImplVersion}.yaml
@@ -28,17 +28,7 @@ put:
     content:
       application/json:
         schema:
-          type: object
-          properties:
-            id:
-              description: Id of the process for which to update the connector, combined with connector name and version separated by slashes (x/y/z)
-              type: string
-            implementation:
-              description: Previously uploaded temp file name of the updated version of the connector (returned by the  [upload file api](#operation/uploadFile))
-              type: string
-        example:
-          id: "8491796209115952722/scripting-groovy-script/1.0.1"
-          implementation: "tmp_7006630415905915150.zip"
+          $ref: '../components/schemas/UpdateProcessConnectorByProcessIdRequest.yaml'
     description: Partial ProcessConnector description
     required: true
   responses:


### PR DESCRIPTION
Inline body in the request was generating code with an `InlineObject` with no definition in code.
Created also an `AnyValue` model to map to the Object class. BDM custom queries can't be typed in the openapi spec since only the final user knows what his query return (object, string,number,...). BDM API respond now with a list of Object instead of "fixed" BusinessData