### PR TITLE
fix(states): add missing state from ActivityState

### DIFF
--- a/openapi/components/schemas/ActivityState.yaml
+++ b/openapi/components/schemas/ActivityState.yaml
@@ -12,3 +12,5 @@ enum:
   - cancelled
   - aborted
   - cancelling subtasks
+  - aborting activity with boundary
+  - completing activity with boundary


### PR DESCRIPTION
That enumeration contains all possible values of the state field of an Activity.

Originaly it comes from the enum org.bonitasoft.engine.bpm.flownode.ActivityStates in bonita-engine.
However that enum is not complete, the 2 states "completing activity with boundary" and "aborting activity with boundary"  are missing

Relates to [BTT-17](https://bonitasoft.atlassian.net/browse/BTT-17)
