### PR TITLE
fix(states): remove activity state enum duplication

### DIFF
--- a/openapi/components/schemas/AbstractTask.yaml
+++ b/openapi/components/schemas/AbstractTask.yaml
@@ -19,9 +19,7 @@ properties:
     description: the human readable task description
     type: string
   state:
-    description: the current state of the task
-    type: string
-    enum: [ initializing,ready,executing,completing,waiting,completed,failed,skipped,cancelled,aborted ]
+    $ref: './ActivityState.yaml'
   reached_state_date:
     description: the date ('yyyy-MM-dd HH:mm:ss.SSS') when this task reached the current state for example '2014-10-17 16:05:42.626'
     type: string


### PR DESCRIPTION
states on AbstractTask was duplicated in ActivityState enum

Relates to [BTT-17](https://bonitasoft.atlassian.net/browse/BTT-17)
