### PR TITLE
tr(gh-action): replace deprecated github actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
       releases:
         type: choice
         description: Choose the release type to do (Following SemVer)
-        options: [ patch, minor, major]
+        options: [ patch, minor, major ]
 
 jobs:
   release:
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 18
+
       - name: Update version
         id: newversion
         run: |
@@ -27,10 +28,12 @@ jobs:
           VERSION=$(cat ./package.json | jq '.version' | tr -d '"')
           sed -i "s/version:.*/version: $VERSION/" openapi/openapi.yaml
           echo "release-tag=$VERSION" >> $GITHUB_OUTPUT
+
       - name: Build
         run: |
           npm ci
           npm run package
+
       - name: Push tag and commit release
         run: |
           git config --global user.email "bonita-ci@bonitasoft.com"
@@ -39,45 +42,17 @@ jobs:
           git commit -m "Release ${{ steps.newversion.outputs.release-tag }}"
           git tag ${{ steps.newversion.outputs.release-tag }}
           git push origin ${{github.ref}} ${{ steps.newversion.outputs.release-tag }}
+
+      - name: Prepare artifacts to release
+        run: |
+          mv dist/openapi.yaml dist-final/bonita-openapi-${{ steps.newversion.outputs.release-tag }}.yaml
+          mv dist/postman.json dist-final/bonita-postman-collection-${{ steps.newversion.outputs.release-tag }}.json
+          mv dist/bonita-openapi-${{ steps.newversion.outputs.release-tag }}.zip dist-final/bonita-openapi-${{ steps.newversion.outputs.release-tag }}.zip
+
       - name: Create Release
         id: create_release
-        uses: actions/create-release@latest
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        uses: ncipollo/release-action@v1
         with:
-          tag_name: ${{ steps.newversion.outputs.release-tag }}
-          release_name: Release ${{ steps.newversion.outputs.release-tag }}
-          draft: false
-          prerelease: false
-      - name: Upload OpenAPI YAML Release Asset
-        id: upload-yaml-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: dist/openapi.yaml
-          asset_name: bonita-openapi-${{ steps.newversion.outputs.release-tag }}.yaml
-          asset_content_type: text/x-yaml
-
-      - name: Upload Postman Collection Release Asset
-        id: upload-postman-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: dist/postman.json
-          asset_name: bonita-postman-collection-${{ steps.newversion.outputs.release-tag }}.json
-          asset_content_type: application/json
-
-      - name: Upload Rest APIs documentation site
-        id: upload-rest-apis-release-asset
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-          asset_path: dist/bonita-openapi-${{ steps.newversion.outputs.release-tag }}.zip
-          asset_name: bonita-openapi-${{ steps.newversion.outputs.release-tag }}.zip
-          asset_content_type: application/zip
+          tag: ${{ steps.newversion.outputs.release-tag }}
+          name: Release ${{ steps.newversion.outputs.release-tag }}
+          artifacts: dist-final/*


### PR DESCRIPTION
actions/create-release & actions/upload-release-asset are not maintained anymore and are running on deprecated Node12 (see https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/)

[JIRA CI-775](https://bonitasoft.atlassian.net/browse/CI-775)