### PR TITLE
fix(diagram): return type is a string

### DIFF
--- a/openapi/paths/API@bpm@diagram@{id}.yaml
+++ b/openapi/paths/API@bpm@diagram@{id}.yaml
@@ -22,9 +22,8 @@ get:
       content:
         application/xml:
           schema:
-            type: object
-            description: Raw XML file containing the diagram definition
-            additionalProperties: true
+            type: string
+            description: BPMN XML representation of the process definition
     '401':
       $ref: '../components/responses/Unauthorized.yaml'
     '403':


### PR DESCRIPTION
Otherwise generated signature returns a Map<String,Object> that cannot be decoded at runtime.

Using a string and removing `additionalProperties` fixes the issue and a string representing the BPMN model in xml is returned.