### PR TITLE
fix(param): Update HumanTaskUpdateRequest.yaml

### DIFF
--- a/openapi/components/schemas/HumanTaskUpdateRequest.yaml
+++ b/openapi/components/schemas/HumanTaskUpdateRequest.yaml
@@ -1,11 +1,11 @@
 type: object
 properties:
-   assignedId:
-     description: assignedId of the HumanTask
+   assigned_id:
+     description: The id of the user to assign this Human task to
      type: string
    state:
      description: state of the HumanTask
      type: string
 example:
-   assignedId: "new_user_id"
+   assigned_id: "1234"
    state: "new_state"


### PR DESCRIPTION
The name of the `assigneeId` parameter is invalid. It should be replaced with `assigned_id` as expected by the API [endpoint implementation](https://github.com/bonitasoft/bonita-engine/blob/dev/bpm/bonita-web-server/src/main/java/org/bonitasoft/web/rest/model/bpm/flownode/IHumanTaskItem.java#L31)

In addition, it seems that some other parameters are not documented like:
* priority (LOWEST, UNDER_NORMAL, NORMAL, ABOVE_NORMAL, HIGHEST)
* dueDate 

Could be a good opportunity to add them.

Fixes https://github.com/bonitasoft/bonita-java-client/issues/284