### PR TITLE
fix(advanced): Fix advanced and editable properties in examples

### DIFF
--- a/openapi/components/schemas/AdvancedApplication.yaml
+++ b/openapi/components/schemas/AdvancedApplication.yaml
@@ -12,7 +12,7 @@ allOf:
     description: Contains the meta information of an advanced Bonita Living Application.
 example:
   id: "306"
-  advanced: true
+  advanced: "true"
   creationDate: "1411548289900"
   icon: ""
   createdBy": "1"
@@ -23,6 +23,6 @@ example:
   displayName: "My advanced app"
   updatedBy: "1"
   visibility: "ALL"
-  editable: true
+  editable: "true"
   lastUpdateDate: "1411548289900"
   version: "1.0"

--- a/openapi/components/schemas/LegacyApplication.yaml
+++ b/openapi/components/schemas/LegacyApplication.yaml
@@ -28,7 +28,7 @@ allOf:
         pattern: '^[A-Za-z0-9\_\-\.]{0,250}$'
 example:
   id: "305"
-  advanced: false
+  advanced: "false"
   creationDate: "1411548289900"
   icon: ""
   createdBy": "1"
@@ -39,7 +39,7 @@ example:
   displayName: "My app"
   updatedBy: "1"
   visibility: "ALL"
-  editable: true
+  editable: "true"
   lastUpdateDate: "1411548289900"
   version: "1.0"
   homePageId: "26"

--- a/openapi/paths/API@living@application.yaml
+++ b/openapi/paths/API@living@application.yaml
@@ -33,7 +33,7 @@ get:
               $ref: '../components/schemas/Application.yaml'
           example:
             - id: "306"
-              advanced: true
+              advanced: "true"
               creationDate: "1411548289900"
               icon: ""
               createdBy": "1"
@@ -44,11 +44,11 @@ get:
               displayName: "My advanced app"
               updatedBy: "1"
               visibility: "ALL"
-              editable: true
+              editable: "true"
               lastUpdateDate: "1411548289900"
               version: "1.0"
             - id: "305"
-              advanced: false
+              advanced: "false"
               creationDate: "1411548289900"
               icon: ""
               createdBy": "1"
@@ -59,7 +59,7 @@ get:
               displayName: "My app"
               updatedBy: "1"
               visibility: "ALL"
-              editable: true
+              editable: "true"
               lastUpdateDate: "1411548289900"
               version: "1.0"
               homePageId: "26"


### PR DESCRIPTION
`advanced` and `editable` properties should be shown as string in the examples