### PR TITLE
docs(bdm data update): add example for ISO-8601 date format

### DIFF
--- a/openapi/paths/API@bdm@businessData@{businessDataType}.yaml
+++ b/openapi/paths/API@bdm@businessData@{businessDataType}.yaml
@@ -114,7 +114,7 @@ post:
     description: |
       The flat JSON object representing the fields of the business data to create.
       
-      The fields to provide depends on the business data type.
+      The fields to provide depend on the business data type.
       
       Any nullable field not provided will be left blank.
       

--- a/openapi/paths/API@bdm@businessData@{businessDataType}.yaml
+++ b/openapi/paths/API@bdm@businessData@{businessDataType}.yaml
@@ -105,9 +105,22 @@ post:
           lastName: Doe
           age: 30
           department: Engineering
+          activity: developer
+          dateOfBirth: "1977-05-26"
+          dateOfBirthWithTime: "1977-05-26T01:59:42"
+          meetingDateAndTimeWithTimezone: "2025-11-29T10:15:30+01:00"
+          otherDateAndTimeWithTimezone: "2025-11-29T10:15:30Z"
           notAValidField: some value that will be ignored
     description: |
-      The flat JSON object representing the business data to create. The fields to provide depends on the business data type.
+      The flat JSON object representing the fields of the business data to create.
+      
+      The fields to provide depends on the business data type.
+      
+      Any nullable field not provided will be left blank.
+      
+      Any unknown field will be ignored and return in the response, under the name "unknownFields".
+      
+      String fields must be enclosed in double quotes (`"`), numeric / boolean fields must not. Date fields must be strings in ISO 8601 format (e.g., `2023-10-01T12:00:00Z`).
     required: true
   responses:
     '200':

--- a/openapi/paths/API@bdm@businessData@{businessDataType}@import.yaml
+++ b/openapi/paths/API@bdm@businessData@{businessDataType}@import.yaml
@@ -10,16 +10,16 @@ post:
     
     Example CSV file content:
     ```csv
-    firstName,lastName,department, dptReference
-    "John","Doe","Engineering", 14
-    "Jane","Smith", "Marketing", 17
+    firstName,lastName,department, dptReference, dateOfBirth, dateOfBirthWithTime, meetingDateAndTimeWithTimezone, otherDateAndTimeWithTimezone
+    "John","Doe","Engineering", 14, "1907-05-26", "1907-05-26T01:59:42", "2025-11-29T10:15:00+01:00", "2025-11-29T10:15:00Z"
+    "Jane","Smith", "Marketing", 17, "1977-03-24", "1977-03-24T17:40:00", "2025-07-19T09:00:00+01:00", "2025-07-19T09:00:00Z"
     ```
     
     Field separator can be comma (`,`) or semicolon (`;`). Space characters around the separator will be ignored (trimmed).
     
     The first line of the CSV file is considered as the header, and must contain the field names, with the exact same upper/lower case.
     
-    String Fields must be enclosed in double quotes (`"`), numeric / boolean fields must not.
+    String fields must be enclosed in double quotes (`"`), numeric / boolean fields must not. Date fields must be strings in ISO 8601 format (e.g., `2023-10-01T12:00:00Z`).
 
 
   operationId: importBusinessData

--- a/openapi/paths/API@bdm@businessData@{businessDataType}@{persistenceId}.yaml
+++ b/openapi/paths/API@bdm@businessData@{businessDataType}@{persistenceId}.yaml
@@ -87,7 +87,7 @@ put:
     description: |
       The flat JSON object representing the fields of the business data to update.
       
-      The fields to provide depends on the business data type.
+      The fields to provide depend on the business data type.
       
       Any field not provided will be left unchanged.
       

--- a/openapi/paths/API@bdm@businessData@{businessDataType}@{persistenceId}.yaml
+++ b/openapi/paths/API@bdm@businessData@{businessDataType}@{persistenceId}.yaml
@@ -69,7 +69,7 @@ put:
       required: true
       schema:
         type: number
-      example: 1234
+      example: "1234"
   requestBody:
     content:
       application/json:
@@ -79,10 +79,21 @@ put:
           firstName: John
           lastName: Wayne
           activity: actor
+          dateOfBirth: "1907-05-26"
+          dateOfBirthWithTime: "1907-05-26T01:59:42"
+          meetingDateAndTimeWithTimezone: "2025-11-29T10:15:30+01:00"
+          otherDateAndTimeWithTimezone: "2025-11-29T10:15:30Z"
           notAValidField: some value that will be ignored
     description: |
-      The flat JSON object representing the fields of the business data to update. The fields to provide depends on the business data type.
+      The flat JSON object representing the fields of the business data to update.
+      
+      The fields to provide depends on the business data type.
+      
       Any field not provided will be left unchanged.
+      
+      Any unknown field will be ignored and return in the response, under the name "unknownFields".
+      
+      String fields must be enclosed in double quotes (`"`), numeric / boolean fields must not. Date fields must be strings in ISO 8601 format (e.g., `2023-10-01T12:00:00Z`).
     required: true
   responses:
     '200':


### PR DESCRIPTION
Example of supported ISO-8601 date formats:

```json
{
        "invoiceDate": "2025-07-17",
        "invoiceDateTime": "2025-07-17T01:59:42",
        "invoiceOffsetDateTime": "2025-11-29T10:15:30+01:00"
}
```

Relates to https://bonitasoft.atlassian.net/browse/BPA-112