### PR TITLE
fix(system/log): Change creation_date format to ISO-8601

### DIFF
--- a/openapi/components/schemas/Log.yaml
+++ b/openapi/components/schemas/Log.yaml
@@ -11,7 +11,7 @@ properties:
   creation_date:
     type: string
     format: date-time
-    description: "the UTC date and time in ISO-8601 format ('yyyy-MM-ddTHH:mm:ssZ') when this log was created, for example '2024-10-17T16:05:42Z'"
+    description: "the UTC date and time in ISO-8601 format ('yyyy-MM-ddTHH:mm:ss.SSSZ') when this log was created, for example '2024-10-17T16:05:42.626Z'"
   createdBy:
     type: string
     description: "the name of the user who triggered the logged action"
@@ -28,7 +28,7 @@ properties:
     description: "the icon path for this log entry"
 example:
   "id": "1024"
-  "creation_date": "2024-10-17T16:05:42Z"
+  "creation_date": "2024-10-17T16:05:42.626Z"
   "createdBy": "walter.bates"
   "severity": "INTERNAL"
   "message": "Creating a new Process definition"

--- a/openapi/components/schemas/Log.yaml
+++ b/openapi/components/schemas/Log.yaml
@@ -10,7 +10,8 @@ properties:
     pattern: '^[A-Za-z0-9\_\-\.]{0,250}$'
   creation_date:
     type: string
-    description: "the UTC date and time in ISO-8601 format ('yyyy-MM-ddTHH:mm:ssZ) when this log was created, for example '2024-10-17T16:05:42Z'"
+    format: date-time
+    description: "the UTC date and time in ISO-8601 format ('yyyy-MM-ddTHH:mm:ssZ') when this log was created, for example '2024-10-17T16:05:42Z'"
   createdBy:
     type: string
     description: "the name of the user who triggered the logged action"

--- a/openapi/components/schemas/Log.yaml
+++ b/openapi/components/schemas/Log.yaml
@@ -10,7 +10,7 @@ properties:
     pattern: '^[A-Za-z0-9\_\-\.]{0,250}$'
   creation_date:
     type: string
-    description: "the date ('yyyy-MM-dd HH:mm:ss.SSS') when this log was created, for example '2024-10-17 16:05:42.626'"
+    description: "the UTC date and time in ISO-8601 format ('yyyy-MM-ddTHH:mm:ssZ) when this log was created, for example '2024-10-17T16:05:42Z'"
   createdBy:
     type: string
     description: "the name of the user who triggered the logged action"
@@ -27,7 +27,7 @@ properties:
     description: "the icon path for this log entry"
 example:
   "id": "1024"
-  "creation_date": "2024-10-17 16:05:42.626"
+  "creation_date": "2024-10-17T16:05:42Z"
   "createdBy": "walter.bates"
   "severity": "INTERNAL"
   "message": "Creating a new Process definition"


### PR DESCRIPTION
Updated the creation_date description and example to reflect ISO-8601 format.

Relates to bonitasoft/bonita-engine-sp/pull/3838