### PR TITLE
feat(retention): document Data Retention REST API

### DIFF
--- a/openapi/components/responses/Conflict.yaml
+++ b/openapi/components/responses/Conflict.yaml
@@ -1,0 +1,7 @@
+description: Conflict, the request could not be completed because it conflicts with the current state of the target resource.
+content:
+  application/json:
+    schema:
+      $ref: '../schemas/Error.yaml'
+    example:
+      message: "Conflict"

--- a/openapi/components/schemas/BusinessObjectWithRetentionRule.yaml
+++ b/openapi/components/schemas/BusinessObjectWithRetentionRule.yaml
@@ -1,0 +1,35 @@
+type: object
+description: |
+  A business object defined in the Business Data Model (BDM) along with its optional data
+  retention rule and composition tree.
+
+  The `dataRetentionRule` field is `null` when no retention rule has been configured for this
+  business object.
+required:
+  - qualifiedName
+  - compositions
+  - dataRetentionRule
+properties:
+  qualifiedName:
+    description: Fully qualified Java class name of the business object.
+    type: string
+  compositions:
+    description: Direct composition children of this business object as a recursive tree.
+    type: array
+    items:
+      $ref: './CompositionNode.yaml'
+  dataRetentionRule:
+    type: object
+    nullable: true
+    allOf:
+      - $ref: './DataRetentionConfig.yaml'
+example:
+  qualifiedName: "com.company.model.Request"
+  compositions: []
+  dataRetentionRule:
+    id: "1"
+    dataClassname: "com.company.model.Request"
+    referenceDate: "CREATION"
+    retentionDays: 365
+    createdAt: "1777473415401"
+    updatedAt: "1777473415401"

--- a/openapi/components/schemas/BusinessObjectWithRetentionRule.yaml
+++ b/openapi/components/schemas/BusinessObjectWithRetentionRule.yaml
@@ -24,11 +24,17 @@ properties:
     allOf:
       - $ref: './DataRetentionConfig.yaml'
 example:
-  qualifiedName: "com.company.model.Request"
-  compositions: []
+  qualifiedName: "com.company.model.Order"
+  compositions:
+    - qualifiedName: "com.company.model.OrderLine"
+      compositions:
+        - qualifiedName: "com.company.model.Product"
+          compositions: []
+    - qualifiedName: "com.company.model.Address"
+      compositions: []
   dataRetentionRule:
     id: "1"
-    dataClassname: "com.company.model.Request"
+    dataClassname: "com.company.model.Order"
     referenceDate: "CREATION"
     retentionDays: 365
     createdAt: "1777473415401"

--- a/openapi/components/schemas/BusinessObjectWithRetentionRule.yaml
+++ b/openapi/components/schemas/BusinessObjectWithRetentionRule.yaml
@@ -1,10 +1,10 @@
 type: object
 description: |
-  A business object defined in the Business Data Model (BDM) along with its optional data
+  A business object type defined in the Business Data Model (BDM) along with its optional data
   retention rule and composition tree.
 
   The `dataRetentionRule` field is `null` when no retention rule has been configured for this
-  business object.
+  business object type.
 required:
   - qualifiedName
   - compositions
@@ -14,7 +14,7 @@ properties:
     description: Fully qualified Java class name of the business object type.
     type: string
   compositions:
-    description: Direct composition children of this business object as a recursive tree.
+    description: Direct composition children of this business object type as a recursive tree.
     type: array
     items:
       $ref: './CompositionNode.yaml'

--- a/openapi/components/schemas/BusinessObjectWithRetentionRule.yaml
+++ b/openapi/components/schemas/BusinessObjectWithRetentionRule.yaml
@@ -11,7 +11,7 @@ required:
   - dataRetentionRule
 properties:
   qualifiedName:
-    description: Fully qualified Java class name of the business object.
+    description: Fully qualified Java class name of the business object type.
     type: string
   compositions:
     description: Direct composition children of this business object as a recursive tree.

--- a/openapi/components/schemas/CompositionNode.yaml
+++ b/openapi/components/schemas/CompositionNode.yaml
@@ -1,0 +1,20 @@
+type: object
+description: |
+  A node in the recursive composition tree of a BDM business object. Each node holds the
+  qualified name of a composed object and the list of its own composed children, allowing
+  arbitrarily deep composition hierarchies to be expressed.
+required:
+  - qualifiedName
+  - compositions
+properties:
+  qualifiedName:
+    description: Fully qualified Java class name of the composed business object.
+    type: string
+  compositions:
+    description: Direct composition children of this object, or an empty list if none.
+    type: array
+    items:
+      $ref: './CompositionNode.yaml'
+example:
+  qualifiedName: "com.company.model.Address"
+  compositions: []

--- a/openapi/components/schemas/CompositionNode.yaml
+++ b/openapi/components/schemas/CompositionNode.yaml
@@ -1,14 +1,14 @@
 type: object
 description: |
-  A node in the recursive composition tree of a BDM business object. Each node holds the
-  qualified name of a composed object and the list of its own composed children, allowing
-  arbitrarily deep composition hierarchies to be expressed.
+  A node in the recursive composition tree of a business object type. Each node holds the
+  qualified name of a composed business object type and the list of its own composed children,
+  allowing arbitrarily deep composition hierarchies to be expressed.
 required:
   - qualifiedName
   - compositions
 properties:
   qualifiedName:
-    description: Fully qualified Java class name of the composed business object.
+    description: Fully qualified Java class name of the composed business object type.
     type: string
   compositions:
     description: Direct composition children of this object, or an empty list if none.

--- a/openapi/components/schemas/DataRetentionConfig.yaml
+++ b/openapi/components/schemas/DataRetentionConfig.yaml
@@ -1,0 +1,38 @@
+type: object
+description: |
+  A data retention rule configured for a specific BDM object type. It defines when and how
+  BDM object instances of a given Java type are automatically deleted by the data retention service.
+required:
+  - id
+  - dataClassname
+  - referenceDate
+  - retentionDays
+  - createdAt
+  - updatedAt
+properties:
+  id:
+    description: Identifier of the retention rule. Serialized as a string to avoid JavaScript precision loss on large `long` values.
+    type: string
+  dataClassname:
+    description: Fully qualified Java class name of the BDM object type this rule applies to. Note the lowercase `n` (the create-rule request body uses `dataClassName` instead).
+    type: string
+  referenceDate:
+    $ref: './ReferenceDate.yaml'
+  retentionDays:
+    description: Duration of the retention period, in days. Always strictly positive — enforced by the engine on create and update.
+    type: integer
+    format: int32
+    minimum: 1
+  createdAt:
+    description: Creation timestamp of this retention rule, in epoch milliseconds. Serialized as a string to avoid JavaScript precision loss.
+    type: string
+  updatedAt:
+    description: Last update timestamp of this retention rule, in epoch milliseconds. Serialized as a string to avoid JavaScript precision loss.
+    type: string
+example:
+  id: "1"
+  dataClassname: "com.company.model.Request"
+  referenceDate: "CREATION"
+  retentionDays: 365
+  createdAt: "1777473415401"
+  updatedAt: "1777473415401"

--- a/openapi/components/schemas/DataRetentionConfig.yaml
+++ b/openapi/components/schemas/DataRetentionConfig.yaml
@@ -1,7 +1,7 @@
 type: object
 description: |
-  A data retention rule configured for a specific BDM object type. It defines when and how
-  BDM object instances of a given Java type are automatically deleted by the data retention service.
+  A data retention rule configured for a specific business object type. It defines when and how
+  business data of that type are automatically deleted by the data retention service.
 required:
   - id
   - dataClassname
@@ -14,7 +14,7 @@ properties:
     description: Identifier of the retention rule. Serialized as a string to avoid JavaScript precision loss on large `long` values.
     type: string
   dataClassname:
-    description: Fully qualified Java class name of the BDM object type this rule applies to. Note the lowercase `n` (the create-rule request body uses `dataClassName` instead).
+    description: Fully qualified Java class name of the business object type this rule applies to. Note the lowercase `n` (the create-rule request body uses `dataClassName` instead).
     type: string
   referenceDate:
     $ref: './ReferenceDate.yaml'

--- a/openapi/components/schemas/ReferenceDate.yaml
+++ b/openapi/components/schemas/ReferenceDate.yaml
@@ -1,0 +1,9 @@
+type: string
+description: |
+  Date field on a BDM object instance used as the starting point of the retention period calculation.
+
+  - `CREATION`: retention is calculated from the creation date of the BDM object instance. The clock never resets.
+  - `LAST_UPDATE`: retention is calculated from the last modification date of the BDM object instance. The clock resets on every modification.
+enum:
+  - CREATION
+  - LAST_UPDATE

--- a/openapi/components/schemas/RetentionRuleCreateRequest.yaml
+++ b/openapi/components/schemas/RetentionRuleCreateRequest.yaml
@@ -1,0 +1,26 @@
+type: object
+description: |
+  Body of `POST /API/retention/rule`. Defines a new data retention rule for the BDM object
+  type identified by `dataClassName`. All three fields are required.
+required:
+  - dataClassName
+  - referenceDate
+  - retentionDays
+properties:
+  dataClassName:
+    description: |
+      Fully qualified Java class name of the BDM object type this rule applies to. Note the uppercase `N`.
+
+      The corresponding field returned in the `DataRetentionConfig` response of this endpoint and of `PUT /API/retention/rule/{ruleId}`, `GET /API/retention/object` is named `dataClassname` (lowercase `n`).
+    type: string
+  referenceDate:
+    $ref: './ReferenceDate.yaml'
+  retentionDays:
+    description: Duration of the retention period, in days. Must be strictly positive.
+    type: integer
+    format: int32
+    minimum: 1
+example:
+  dataClassName: "com.company.model.ContratClient"
+  referenceDate: "LAST_UPDATE"
+  retentionDays: 365

--- a/openapi/components/schemas/RetentionRuleCreateRequest.yaml
+++ b/openapi/components/schemas/RetentionRuleCreateRequest.yaml
@@ -1,6 +1,6 @@
 type: object
 description: |
-  Body of `POST /API/retention/rule`. Defines a new data retention rule for the BDM object
+  Body of `POST /API/retention/rule`. Defines a new data retention rule for the business object
   type identified by `dataClassName`. All three fields are required.
 required:
   - dataClassName
@@ -9,7 +9,7 @@ required:
 properties:
   dataClassName:
     description: |
-      Fully qualified Java class name of the BDM object type this rule applies to. Note the uppercase `N`.
+      Fully qualified Java class name of the business object type this rule applies to. Note the uppercase `N`.
 
       The corresponding field returned in the `DataRetentionConfig` response of this endpoint and of `PUT /API/retention/rule/{ruleId}`, `GET /API/retention/object` is named `dataClassname` (lowercase `n`).
     type: string

--- a/openapi/components/schemas/RetentionRuleUpdateRequest.yaml
+++ b/openapi/components/schemas/RetentionRuleUpdateRequest.yaml
@@ -1,0 +1,20 @@
+type: object
+description: |
+  Body of `PUT /API/retention/rule/{ruleId}`. Replaces the mutable fields of an existing
+  retention rule. This is a full replacement of `referenceDate` and `retentionDays`, not a
+  partial update — both fields must be provided on every call. The `dataClassName` of an
+  existing rule cannot be changed.
+required:
+  - referenceDate
+  - retentionDays
+properties:
+  referenceDate:
+    $ref: './ReferenceDate.yaml'
+  retentionDays:
+    description: Duration of the retention period, in days. Must be strictly positive.
+    type: integer
+    format: int32
+    minimum: 1
+example:
+  referenceDate: "CREATION"
+  retentionDays: 730

--- a/openapi/components/schemas/RetentionSchedule.yaml
+++ b/openapi/components/schemas/RetentionSchedule.yaml
@@ -1,0 +1,12 @@
+type: object
+description: |
+  Schedule on which the data retention service runs. The cron expression is configured via the
+  `bonita.runtime.retention.schedule.cron` platform property.
+required:
+  - cronExpression
+properties:
+  cronExpression:
+    description: Cron expression that defines when the data retention job is triggered.
+    type: string
+example:
+  cronExpression: "0 0 2 * * 6"

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -37,6 +37,7 @@ x-tagGroups:
       - BusinessDataQuery
       - Business Data Operations
       - BDMAccessControl
+      - DataRetention
   - name: BPM
     tags:
       - Activity
@@ -256,6 +257,12 @@ tags:
   - name: CustomUserValue
     x-displayName: CustomUserValue
     description: CustomUserValue
+  - name: DataRetention
+    x-displayName: Data Retention
+    description: |
+      Configure how Bonita automatically deletes obsolete Business Data Model (BDM) instances. A retention rule applies to a specific BDM business object type and defines when its instances become eligible for deletion based on a reference date (creation or last update) and a retention period in days. The data retention service runs on a configurable cron schedule.
+
+      This Web REST API is available in **Enterprise editions only**, since version 11.0.
   - name: Diagram
     x-displayName: Diagram
     description: Diagram
@@ -429,6 +436,17 @@ paths:
     $ref: './paths/portal@bdmAccessControlUpload.yaml'
   /services/bdmAccessControl/install:
     $ref: './paths/services@bdmAccessControl@install.yaml'
+  #  =======================
+  #   DATA RETENTION API
+  #  =======================
+  /API/retention/object:
+    $ref: './paths/API@retention@object.yaml'
+  /API/retention/schedule:
+    $ref: './paths/API@retention@schedule.yaml'
+  /API/retention/rule:
+    $ref: './paths/API@retention@rule.yaml'
+  '/API/retention/rule/{ruleId}':
+    $ref: './paths/API@retention@rule@{ruleId}.yaml'
   #  =======================
   #   BPM API
   #  =======================

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -260,7 +260,7 @@ tags:
   - name: DataRetention
     x-displayName: Data Retention
     description: |
-      Configure how Bonita automatically deletes obsolete Business Data Model (BDM) instances. A retention rule applies to a specific BDM business object type and defines when its instances become eligible for deletion based on a reference date (creation or last update) and a retention period in days. The data retention service runs on a configurable cron schedule.
+      Configure how Bonita automatically deletes obsolete business data. A retention rule applies to a specific business object type and defines when its instances become eligible for deletion based on a reference date (creation or last update) and a retention period in days. The data retention service runs on a configurable cron schedule.
 
       This Web REST API is available in **Enterprise editions only**, since version 11.0.
   - name: Diagram

--- a/openapi/paths/API@retention@object.yaml
+++ b/openapi/paths/API@retention@object.yaml
@@ -1,0 +1,31 @@
+get:
+  tags:
+    - DataRetention
+  summary: List BDM business objects with their retention rules
+  description: |
+    ![edition](https://img.shields.io/badge/edition-entreprise-blue)
+
+    Returns the list of all business objects defined in the deployed Business Data Model (BDM),
+    each enriched with its composition tree and the retention rule that may apply to it.
+
+    The full list is returned in a single response — pagination is not applied because the
+    BDM is a bounded set defined at deployment time.
+
+    Requires the `DATA_RETENTION` feature to be active in the platform license.
+    Available since Bonita 11.0.
+  operationId: findObjectsWithRetentionRules
+  responses:
+    '200':
+      description: Successful operation
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '../components/schemas/BusinessObjectWithRetentionRule.yaml'
+    '401':
+      $ref: '../components/responses/Unauthorized.yaml'
+    '403':
+      $ref: '../components/responses/Forbidden.yaml'
+    '5XX':
+      $ref: '../components/responses/ServerError.yaml'

--- a/openapi/paths/API@retention@object.yaml
+++ b/openapi/paths/API@retention@object.yaml
@@ -8,7 +8,7 @@ get:
     Returns the list of all business object types defined in the deployed Business Data Model (BDM),
     each enriched with its composition tree and the retention rule that may apply to it.
 
-    The full list is returned in a single response — pagination is not applied because the
+    The full list is returned in a single response. Pagination is not applied because the
     BDM is a bounded set defined at deployment time.
 
     Requires the `DATA_RETENTION` feature to be active in the platform license.

--- a/openapi/paths/API@retention@object.yaml
+++ b/openapi/paths/API@retention@object.yaml
@@ -1,11 +1,11 @@
 get:
   tags:
     - DataRetention
-  summary: List BDM business objects with their retention rules
+  summary: List business object types with their retention rules
   description: |
     ![edition](https://img.shields.io/badge/edition-entreprise-blue)
 
-    Returns the list of all business objects defined in the deployed Business Data Model (BDM),
+    Returns the list of all business object types defined in the deployed Business Data Model (BDM),
     each enriched with its composition tree and the retention rule that may apply to it.
 
     The full list is returned in a single response — pagination is not applied because the

--- a/openapi/paths/API@retention@object.yaml
+++ b/openapi/paths/API@retention@object.yaml
@@ -16,7 +16,9 @@ get:
   operationId: findObjectsWithRetentionRules
   responses:
     '200':
-      description: Successful operation
+      description: |
+        Successful operation. The full list of business object types is returned in a single
+        response — no pagination is applied and no `Content-Range` header is set.
       content:
         application/json:
           schema:

--- a/openapi/paths/API@retention@object.yaml
+++ b/openapi/paths/API@retention@object.yaml
@@ -18,7 +18,7 @@ get:
     '200':
       description: |
         Successful operation. The full list of business object types is returned in a single
-        response — no pagination is applied and no `Content-Range` header is set.
+        response. No pagination is applied and no `Content-Range` header is set.
       content:
         application/json:
           schema:

--- a/openapi/paths/API@retention@rule.yaml
+++ b/openapi/paths/API@retention@rule.yaml
@@ -1,0 +1,41 @@
+post:
+  tags:
+    - DataRetention
+  summary: Create a retention rule
+  description: |
+    ![edition](https://img.shields.io/badge/edition-entreprise-blue)
+
+    Creates a data retention rule for a BDM business object type. Once created, the data retention
+    service will automatically delete instances of `dataClassName` whose `referenceDate` is older
+    than `retentionDays` days.
+
+    Only one retention rule can exist per BDM class name. Posting a second rule for a
+    `dataClassName` that already has one returns `409 Conflict`.
+
+    Requires the `DATA_RETENTION` feature to be active in the platform license.
+    Available since Bonita 11.0.
+  operationId: createRetentionRule
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../components/schemas/RetentionRuleCreateRequest.yaml'
+  responses:
+    '201':
+      description: Retention rule created
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/DataRetentionConfig.yaml'
+    '400':
+      $ref: '../components/responses/BadRequest.yaml'
+    '401':
+      $ref: '../components/responses/Unauthorized.yaml'
+    '403':
+      $ref: '../components/responses/Forbidden.yaml'
+    '409':
+      $ref: '../components/responses/Conflict.yaml'
+    '5XX':
+      $ref: '../components/responses/ServerError.yaml'
+  x-codegen-request-body-name: body

--- a/openapi/paths/API@retention@rule.yaml
+++ b/openapi/paths/API@retention@rule.yaml
@@ -5,9 +5,9 @@ post:
   description: |
     ![edition](https://img.shields.io/badge/edition-entreprise-blue)
 
-    Creates a data retention rule for a BDM business object type. Once created, the data retention
-    service will automatically delete instances of `dataClassName` whose `referenceDate` is older
-    than `retentionDays` days.
+    Creates a data retention rule for a business object type. Once created, the data retention
+    service will automatically delete business data of `dataClassName` whose `referenceDate` is
+    older than `retentionDays` days.
 
     Only one retention rule can exist per BDM class name. Posting a second rule for a
     `dataClassName` that already has one returns `409 Conflict`.

--- a/openapi/paths/API@retention@rule@{ruleId}.yaml
+++ b/openapi/paths/API@retention@rule@{ruleId}.yaml
@@ -1,0 +1,80 @@
+put:
+  tags:
+    - DataRetention
+  summary: Update a retention rule by ID
+  description: |
+    ![edition](https://img.shields.io/badge/edition-entreprise-blue)
+
+    Updates the `referenceDate` and/or `retentionDays` of an existing retention rule. The
+    `dataClassName` of an existing rule cannot be changed and is ignored if present in the
+    request body.
+
+    Requires the `DATA_RETENTION` feature to be active in the platform license.
+    Available since Bonita 11.0.
+  operationId: updateRetentionRuleById
+  parameters:
+    - description: Numeric ID of the retention rule to update (the `id` field returned by `DataRetentionConfig`).
+      in: path
+      name: ruleId
+      required: true
+      schema:
+        type: string
+        pattern: '^[0-9]+$'
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../components/schemas/RetentionRuleUpdateRequest.yaml'
+  responses:
+    '200':
+      description: Retention rule updated
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/DataRetentionConfig.yaml'
+    '400':
+      $ref: '../components/responses/BadRequest.yaml'
+    '401':
+      $ref: '../components/responses/Unauthorized.yaml'
+    '403':
+      $ref: '../components/responses/Forbidden.yaml'
+    '404':
+      $ref: '../components/responses/NotFound.yaml'
+    '5XX':
+      $ref: '../components/responses/ServerError.yaml'
+  x-codegen-request-body-name: body
+delete:
+  tags:
+    - DataRetention
+  summary: Delete a retention rule by ID
+  description: |
+    ![edition](https://img.shields.io/badge/edition-entreprise-blue)
+
+    Deletes the retention rule with the given ID. Existing BDM object instances of the underlying
+    type are not deleted by this operation; only the retention rule itself is removed.
+
+    Requires the `DATA_RETENTION` feature to be active in the platform license.
+    Available since Bonita 11.0.
+  operationId: deleteRetentionRuleById
+  parameters:
+    - description: Numeric ID of the retention rule to delete (the `id` field returned by `DataRetentionConfig`).
+      in: path
+      name: ruleId
+      required: true
+      schema:
+        type: string
+        pattern: '^[0-9]+$'
+  responses:
+    '204':
+      $ref: '../components/responses/NoContent.yaml'
+    '400':
+      $ref: '../components/responses/BadRequest.yaml'
+    '401':
+      $ref: '../components/responses/Unauthorized.yaml'
+    '403':
+      $ref: '../components/responses/Forbidden.yaml'
+    '404':
+      $ref: '../components/responses/NotFound.yaml'
+    '5XX':
+      $ref: '../components/responses/ServerError.yaml'

--- a/openapi/paths/API@retention@rule@{ruleId}.yaml
+++ b/openapi/paths/API@retention@rule@{ruleId}.yaml
@@ -66,8 +66,6 @@ delete:
   responses:
     '204':
       $ref: '../components/responses/NoContent.yaml'
-    '400':
-      $ref: '../components/responses/BadRequest.yaml'
     '401':
       $ref: '../components/responses/Unauthorized.yaml'
     '403':

--- a/openapi/paths/API@retention@rule@{ruleId}.yaml
+++ b/openapi/paths/API@retention@rule@{ruleId}.yaml
@@ -5,9 +5,7 @@ put:
   description: |
     ![edition](https://img.shields.io/badge/edition-entreprise-blue)
 
-    Updates the `referenceDate` and/or `retentionDays` of an existing retention rule. The
-    `dataClassName` of an existing rule cannot be changed and is ignored if present in the
-    request body.
+    Updates the `referenceDate` and `retentionDays` of an existing retention rule.
 
     Requires the `DATA_RETENTION` feature to be active in the platform license.
     Available since Bonita 11.0.

--- a/openapi/paths/API@retention@schedule.yaml
+++ b/openapi/paths/API@retention@schedule.yaml
@@ -1,0 +1,26 @@
+get:
+  tags:
+    - DataRetention
+  summary: Get the data retention schedule
+  description: |
+    ![edition](https://img.shields.io/badge/edition-entreprise-blue)
+
+    Returns the cron expression that triggers the data retention job. The expression is configured
+    via the `bonita.runtime.retention.schedule.cron` platform property and is read-only at runtime.
+
+    Requires the `DATA_RETENTION` feature to be active in the platform license.
+    Available since Bonita 11.0.
+  operationId: getRetentionSchedule
+  responses:
+    '200':
+      description: Successful operation
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/RetentionSchedule.yaml'
+    '401':
+      $ref: '../components/responses/Unauthorized.yaml'
+    '403':
+      $ref: '../components/responses/Forbidden.yaml'
+    '5XX':
+      $ref: '../components/responses/ServerError.yaml'


### PR DESCRIPTION
## Summary

Document the new **Data Retention (GDPR)** REST API used by the `admin-data-retention` administration application:

- `GET /API/retention/object` — list BDM business objects with their retention rules and composition tree
- `GET /API/retention/schedule` — read the cron expression that triggers the data retention job
- `POST /API/retention/rule` — create a retention rule for a BDM type
- `PUT /API/retention/rule/{ruleId}` — update `referenceDate` / `retentionDays`
- `DELETE /API/retention/rule/{ruleId}` — delete a retention rule

Adds the supporting schemas under `openapi/components/schemas/`:

- Response: `DataRetentionConfig`, `BusinessObjectWithRetentionRule`, `CompositionNode`, `ReferenceDate`, `RetentionSchedule`
- Request: `RetentionRuleCreateRequest`, `RetentionRuleUpdateRequest`

A new shared response component `openapi/components/responses/Conflict.yaml` is introduced to model the `409 Conflict` returned when posting a duplicate `dataClassName` (one rule per BDM class invariant). A `DataRetention` tag is registered under the existing **BDM** tag group.

Available in Enterprise editions only, since Bonita 11.0.

Schemas were derived from the engine source (`com.bonitasoft.web.rest.server.api.bdm.RetentionObjectController`, `RetentionRuleController`, `RetentionScheduleController`, the `BusinessDataAPI` interface and the `DataRetentionConfig` / `BusinessObjectWithRetentionRule` / `CompositionNode` / `ReferenceDate` model types) and validated against a live runtime via a POST → PUT → DELETE round-trip on a local server. The 409 response is backed by `RetentionRuleControllerTest#createRetentionRule_should_return_conflict_when_rule_already_exists`.

### Notes

- The BDM class name is intentionally exposed with two different casings: the request body uses `dataClassName` (uppercase `N`) while the response field is `dataClassname` (lowercase `n`). This mirrors the engine's actual JSON output and is documented in the field descriptions.
- `GET /API/retention/object` is intentionally not paginated — the BDM is a bounded set defined at deployment time.
- Bean validation on POST/PUT bodies (`@NotNull`, `@Positive`) is annotated server-side but currently does not fire on the running build, so invalid bodies fall through to `5XX` instead of `400`. The spec documents the intended `400` and lets `5XX` cover the current behavior.

## Test plan

- [x] `npm test` passes (no new lint errors; only pre-existing warnings unrelated to this PR remain)
- [x] `npm run yaml` bundles cleanly into `dist/openapi.yaml`
- [x] Live `GET /API/retention/object` matches the documented shape (string-encoded longs, nullable `dataRetentionRule`, `referenceDate` enum)
- [x] Live `GET /API/retention/schedule` matches `{ cronExpression }`
- [x] Live `POST /API/retention/rule` returns 201 with a `DataRetentionConfig`
- [x] Live `PUT /API/retention/rule/{ruleId}` returns 200 with the updated config; `dataClassname` is preserved
- [x] Live `DELETE /API/retention/rule/{ruleId}` returns 204; subsequent `PUT` on the same id returns 404
- [x] 409 on duplicate-rule creation backed by `RetentionRuleControllerTest` (not re-exercised live)