### PR TITLE
feat(delegation): document Delegation REST API

### DIFF
--- a/openapi/components/schemas/DelegatedTask.yaml
+++ b/openapi/components/schemas/DelegatedTask.yaml
@@ -12,8 +12,9 @@ description: |
   without a second round-trip.
 
   All long id fields are serialized as strings to avoid JavaScript precision loss. Date fields
-  (`dueDate`, `assignedDate`, `reachedStateDate`, `lastUpdateDate`) are serialized as numeric
-  epoch milliseconds and may be `null`.
+  (`dueDate`, `assignedDate`, `reachedStateDate`, `lastUpdateDate`, `delegationStart`,
+  `delegationEnd`) are numeric, in milliseconds since epoch; some (such as `dueDate` and
+  `assignedDate`) may be `null`.
 required:
   - id
   - name
@@ -112,11 +113,13 @@ properties:
     description: The user the task is surfaced to through delegation (the delegate).
     $ref: './DelegationUser.yaml'
   delegationStart:
-    description: Start of the delegation period, inclusive, in epoch milliseconds. Serialized as a string (unlike the numeric task date fields above), mirroring engine output. Same value as the delegation rule's `startDate`.
-    type: string
+    description: Start of the delegation period, inclusive, in milliseconds since epoch. Same value as the delegation rule's `startDate`.
+    type: integer
+    format: int64
   delegationEnd:
-    description: End of the delegation period, inclusive, in epoch milliseconds. Serialized as a string (unlike the numeric task date fields above), mirroring engine output. Same value as the delegation rule's `endDate`.
-    type: string
+    description: End of the delegation period, inclusive, in milliseconds since epoch. Same value as the delegation rule's `endDate`.
+    type: integer
+    format: int64
   rootProcessInfo:
     description: Deployment information of the process behind the root case that triggered the task, not the child case the task may directly belong to.
     $ref: './ProcessDeploymentInfo.yaml'
@@ -141,8 +144,8 @@ example:
   executedBy: "0"
   executedBySubstitute: "0"
   flownodeDefinitionId: "7537946595085140972"
-  delegationStart: "1780524000000"
-  delegationEnd: "1780696799999"
+  delegationStart: 1780524000000
+  delegationEnd: 1780696799999
   delegator:
     id: "1"
     firstName: "Walter"

--- a/openapi/components/schemas/DelegatedTask.yaml
+++ b/openapi/components/schemas/DelegatedTask.yaml
@@ -1,6 +1,6 @@
 type: object
 description: |
-  A human task that the current user is allowed to act on through an active delegation rule,
+  A human task that a user is allowed to act on through an active delegation rule,
   returned by `GET /API/delegation/task`.
 
   The task is still assigned to the delegator; delegation grants the delegate visibility and

--- a/openapi/components/schemas/DelegatedTask.yaml
+++ b/openapi/components/schemas/DelegatedTask.yaml
@@ -112,13 +112,13 @@ properties:
     description: The user the task is surfaced to through delegation (the delegate).
     $ref: './DelegationUser.yaml'
   delegationStart:
-    description: Start of the delegation period, inclusive, in epoch milliseconds. Serialized as a string. Same value as the delegation rule's `startDate`.
+    description: Start of the delegation period, inclusive, in epoch milliseconds. Serialized as a string (unlike the numeric task date fields above), mirroring engine output. Same value as the delegation rule's `startDate`.
     type: string
   delegationEnd:
-    description: End of the delegation period, inclusive, in epoch milliseconds. Serialized as a string. Same value as the delegation rule's `endDate`.
+    description: End of the delegation period, inclusive, in epoch milliseconds. Serialized as a string (unlike the numeric task date fields above), mirroring engine output. Same value as the delegation rule's `endDate`.
     type: string
   rootProcessInfo:
-    description: Deployment information of the root process the task belongs to.
+    description: Deployment information of the process behind the root case that triggered the task, not the child case the task may directly belong to.
     $ref: './ProcessDeploymentInfo.yaml'
 example:
   id: "2"

--- a/openapi/components/schemas/DelegatedTask.yaml
+++ b/openapi/components/schemas/DelegatedTask.yaml
@@ -1,0 +1,186 @@
+type: object
+description: |
+  A human task that the current user is allowed to act on through an active delegation rule,
+  returned by `GET /API/delegation/task`.
+
+  The task is still assigned to the delegator; delegation grants the delegate visibility and
+  execution rights but does not reassign ownership. The shape aligns with the legacy human-task
+  REST format (modernised to camelCase): `processDefinitionId` is exposed as `processId`,
+  `parentProcessInstanceId` as `parentCaseId`, `rootContainerId` as `rootCaseId`,
+  `expectedEndDate` as `dueDate` and `claimedDate` as `assignedDate`. The delegator, delegate
+  and delegation window are added on top so the front-end can render the delegation context
+  without a second round-trip.
+
+  All long id fields are serialized as strings to avoid JavaScript precision loss. Date fields
+  (`dueDate`, `assignedDate`, `reachedStateDate`, `lastUpdateDate`) are serialized as numeric
+  epoch milliseconds and may be `null`.
+required:
+  - id
+  - name
+  - displayName
+  - state
+  - type
+  - priority
+  - processId
+  - parentCaseId
+  - rootCaseId
+  - actorId
+  - assigneeId
+  - executedBy
+  - executedBySubstitute
+  - flownodeDefinitionId
+  - delegator
+  - delegate
+  - delegationStart
+  - delegationEnd
+  - rootProcessInfo
+properties:
+  id:
+    description: Identifier of the task instance. Serialized as a string to avoid JavaScript precision loss.
+    type: string
+  name:
+    description: Technical name of the task.
+    type: string
+  displayName:
+    description: Human-readable name of the task.
+    type: string
+    nullable: true
+  description:
+    description: Description of the task.
+    type: string
+    nullable: true
+  displayDescription:
+    description: Human-readable description of the task.
+    type: string
+    nullable: true
+  state:
+    description: Current state of the task (e.g. `ready`).
+    type: string
+  type:
+    description: Flow node type (e.g. `USER_TASK`).
+    type: string
+  priority:
+    description: Priority of the task (e.g. `NORMAL`).
+    type: string
+    nullable: true
+  dueDate:
+    description: Expected end date of the task, in epoch milliseconds, or `null` when none is set. (Maps to the engine `expectedEndDate`.)
+    type: integer
+    format: int64
+    nullable: true
+  assignedDate:
+    description: Date the task was claimed by its assignee, in epoch milliseconds, or `null` when unassigned. (Maps to the engine `claimedDate`.)
+    type: integer
+    format: int64
+    nullable: true
+  reachedStateDate:
+    description: Date the task reached its current state, in epoch milliseconds.
+    type: integer
+    format: int64
+  lastUpdateDate:
+    description: Date the task was last updated, in epoch milliseconds.
+    type: integer
+    format: int64
+  processId:
+    description: Identifier of the process definition. Serialized as a string. (Maps to the engine `processDefinitionId`.)
+    type: string
+  parentCaseId:
+    description: Identifier of the immediate containing process instance. Serialized as a string. (Maps to the engine `parentProcessInstanceId`.)
+    type: string
+  rootCaseId:
+    description: Identifier of the root process instance. Serialized as a string. (Maps to the engine `rootContainerId`.)
+    type: string
+  actorId:
+    description: Id of the actor that can execute this task. Serialized as a string.
+    type: string
+  assigneeId:
+    description: Id of the user this task is assigned to, or `0` if unassigned. Serialized as a string.
+    type: string
+  executedBy:
+    description: Id of the user who performed the task, or `0` if not yet executed. Serialized as a string.
+    type: string
+  executedBySubstitute:
+    description: Id of the user who performed the task on behalf of someone else, or `0` otherwise. Serialized as a string.
+    type: string
+  flownodeDefinitionId:
+    description: Identifier of the flow node definition. Serialized as a string.
+    type: string
+  delegator:
+    description: The user whose task this is (the delegator).
+    $ref: './DelegationUser.yaml'
+  delegate:
+    description: The user the task is surfaced to through delegation (the delegate).
+    $ref: './DelegationUser.yaml'
+  delegationStart:
+    description: Start of the delegation period, inclusive, in epoch milliseconds. Serialized as a string. Same value as the delegation rule's `startDate`.
+    type: string
+  delegationEnd:
+    description: End of the delegation period, inclusive, in epoch milliseconds. Serialized as a string. Same value as the delegation rule's `endDate`.
+    type: string
+  rootProcessInfo:
+    description: Deployment information of the root process the task belongs to.
+    $ref: './ProcessDeploymentInfo.yaml'
+example:
+  id: "2"
+  name: "Validate request"
+  displayName: "Validate request"
+  description: null
+  displayDescription: null
+  state: "ready"
+  type: "USER_TASK"
+  priority: "NORMAL"
+  dueDate: null
+  assignedDate: 1780576627723
+  reachedStateDate: 1780576595140
+  lastUpdateDate: 1780576627723
+  processId: "5270206374128493046"
+  parentCaseId: "1"
+  rootCaseId: "1"
+  actorId: "1"
+  assigneeId: "1"
+  executedBy: "0"
+  executedBySubstitute: "0"
+  flownodeDefinitionId: "7537946595085140972"
+  delegationStart: "1780524000000"
+  delegationEnd: "1780696799999"
+  delegator:
+    id: "1"
+    firstName: "Walter"
+    lastName: "Bates"
+    userName: "walter.bates"
+    iconId: null
+    title: null
+    jobTitle: null
+    creationDate: 1780477756657
+    createdBy: "-1"
+    lastUpdate: 1780477756657
+    lastConnection: 1780576504806
+    managerUserId: "0"
+    enabled: true
+  delegate:
+    id: "2"
+    firstName: "Michael"
+    lastName: "Scott"
+    userName: "michael.scott"
+    iconId: null
+    title: null
+    jobTitle: null
+    creationDate: 1780477806557
+    createdBy: "-1"
+    lastUpdate: 1780477806557
+    lastConnection: null
+    managerUserId: "0"
+    enabled: true
+  rootProcessInfo:
+    name: "Vacation request"
+    version: "1.0"
+    displayDescription: ""
+    deploymentDate: 1780576273140
+    deployedBy: "1"
+    configurationState: "RESOLVED"
+    activationState: "ENABLED"
+    processId: "5270206374128493046"
+    displayName: "Vacation request"
+    lastUpdateDate: 1780576574182
+    iconPath: null
+    description: ""

--- a/openapi/components/schemas/DelegationRule.yaml
+++ b/openapi/components/schemas/DelegationRule.yaml
@@ -28,11 +28,13 @@ properties:
     description: The user receiving visibility and execution rights on the delegator's tasks.
     $ref: './DelegationUser.yaml'
   startDate:
-    description: Start of the delegation period, inclusive, in epoch milliseconds. Serialized as a string to avoid JavaScript precision loss.
-    type: string
+    description: Start of the delegation period, inclusive, in milliseconds since epoch.
+    type: integer
+    format: int64
   endDate:
-    description: End of the delegation period, inclusive, in epoch milliseconds. Serialized as a string to avoid JavaScript precision loss.
-    type: string
+    description: End of the delegation period, inclusive, in milliseconds since epoch.
+    type: integer
+    format: int64
   processes:
     description: |
       Process whitelist for this rule. Each entry is a process name; a name covers every deployed
@@ -47,8 +49,9 @@ properties:
     description: The user who last created or modified this rule (the delegator on self-service, or an administrator).
     $ref: './DelegationUser.yaml'
   lastUpdatedAt:
-    description: Timestamp of the last modification, in epoch milliseconds. Serialized as a string to avoid JavaScript precision loss.
-    type: string
+    description: Timestamp of the last modification, in milliseconds since epoch.
+    type: integer
+    format: int64
 example:
   id: "1"
   delegator:
@@ -79,8 +82,8 @@ example:
     lastConnection: null
     managerUserId: "0"
     enabled: true
-  startDate: "1780524000000"
-  endDate: "1780696799999"
+  startDate: 1780524000000
+  endDate: 1780696799999
   processes:
     - "Vacation request"
   status: "active"
@@ -98,4 +101,4 @@ example:
     lastConnection: 1780576504806
     managerUserId: "0"
     enabled: true
-  lastUpdatedAt: "1780576300586"
+  lastUpdatedAt: 1780576300586

--- a/openapi/components/schemas/DelegationRule.yaml
+++ b/openapi/components/schemas/DelegationRule.yaml
@@ -38,6 +38,7 @@ properties:
       Process whitelist for this rule. Each entry is a process name; a name covers every deployed
       version of that process. Always contains at least one entry.
     type: array
+    minItems: 1
     items:
       type: string
   status:

--- a/openapi/components/schemas/DelegationRule.yaml
+++ b/openapi/components/schemas/DelegationRule.yaml
@@ -1,0 +1,100 @@
+type: object
+description: |
+  A task delegation rule: a user (the delegator) grants another user (the delegate) the ability
+  to see and execute the delegator's human tasks during a bounded period, for a whitelist of
+  processes.
+
+  Delegation is not reassignment: tasks stay assigned to the delegator, and the delegate only
+  gains visibility and execution rights through dedicated views. A user can hold at most one
+  delegation rule at a time.
+required:
+  - id
+  - delegator
+  - delegate
+  - startDate
+  - endDate
+  - processes
+  - status
+  - lastUpdatedBy
+  - lastUpdatedAt
+properties:
+  id:
+    description: Identifier of the delegation rule. Serialized as a string to avoid JavaScript precision loss on large `long` values.
+    type: string
+  delegator:
+    description: The user whose tasks are delegated.
+    $ref: './DelegationUser.yaml'
+  delegate:
+    description: The user receiving visibility and execution rights on the delegator's tasks.
+    $ref: './DelegationUser.yaml'
+  startDate:
+    description: Start of the delegation period, inclusive, in epoch milliseconds. Serialized as a string to avoid JavaScript precision loss.
+    type: string
+  endDate:
+    description: End of the delegation period, inclusive, in epoch milliseconds. Serialized as a string to avoid JavaScript precision loss.
+    type: string
+  processes:
+    description: |
+      Process whitelist for this rule. Each entry is a process name; a name covers every deployed
+      version of that process. Always contains at least one entry.
+    type: array
+    items:
+      type: string
+  status:
+    $ref: './DelegationStatus.yaml'
+  lastUpdatedBy:
+    description: The user who last created or modified this rule (the delegator on self-service, or an administrator).
+    $ref: './DelegationUser.yaml'
+  lastUpdatedAt:
+    description: Timestamp of the last modification, in epoch milliseconds. Serialized as a string to avoid JavaScript precision loss.
+    type: string
+example:
+  id: "1"
+  delegator:
+    id: "1"
+    firstName: "Walter"
+    lastName: "Bates"
+    userName: "walter.bates"
+    iconId: null
+    title: null
+    jobTitle: null
+    creationDate: 1780477756657
+    createdBy: "-1"
+    lastUpdate: 1780477756657
+    lastConnection: 1780576504806
+    managerUserId: "0"
+    enabled: true
+  delegate:
+    id: "2"
+    firstName: "Michael"
+    lastName: "Scott"
+    userName: "michael.scott"
+    iconId: null
+    title: null
+    jobTitle: null
+    creationDate: 1780477806557
+    createdBy: "-1"
+    lastUpdate: 1780477806557
+    lastConnection: null
+    managerUserId: "0"
+    enabled: true
+  startDate: "1780524000000"
+  endDate: "1780696799999"
+  processes:
+    - "Vacation request"
+  status: "active"
+  lastUpdatedBy:
+    id: "1"
+    firstName: "Walter"
+    lastName: "Bates"
+    userName: "walter.bates"
+    iconId: null
+    title: null
+    jobTitle: null
+    creationDate: 1780477756657
+    createdBy: "-1"
+    lastUpdate: 1780477756657
+    lastConnection: 1780576504806
+    managerUserId: "0"
+    enabled: true
+  lastUpdatedAt: "1780576300586"

--- a/openapi/components/schemas/DelegationRuleCreateRequest.yaml
+++ b/openapi/components/schemas/DelegationRuleCreateRequest.yaml
@@ -1,0 +1,47 @@
+type: object
+description: |
+  Body of `POST /API/delegation/rule`. Defines a new delegation rule.
+
+  `delegatorId` is optional: when omitted it is resolved from the current session
+  (self-service creation). An administrator creating a rule on behalf of another user provides
+  `delegatorId` explicitly.
+
+  The values must satisfy: `endDate` strictly after `startDate`, `delegateId` different from the
+  delegator, and a non-empty `processes` list. A violation is reported as `400`.
+
+  A user can hold at most one delegation rule: posting a rule for a delegator who already has one
+  replaces the existing rule (upsert).
+required:
+  - delegateId
+  - startDate
+  - endDate
+  - processes
+properties:
+  delegatorId:
+    description: Id of the user whose tasks are delegated. Optional; resolved from the session when omitted.
+    type: integer
+    format: int64
+  delegateId:
+    description: Id of the user receiving access. Must differ from the delegator.
+    type: integer
+    format: int64
+  startDate:
+    description: Start of the delegation period, inclusive, in epoch milliseconds.
+    type: integer
+    format: int64
+  endDate:
+    description: End of the delegation period, inclusive, in epoch milliseconds. Must be strictly after `startDate`.
+    type: integer
+    format: int64
+  processes:
+    description: Process whitelist. Each entry is a process name covering every deployed version. Must contain at least one entry.
+    type: array
+    items:
+      type: string
+example:
+  delegatorId: 1
+  delegateId: 2
+  startDate: 1780524000000
+  endDate: 1780696799999
+  processes:
+    - "Vacation request"

--- a/openapi/components/schemas/DelegationRuleCreateRequest.yaml
+++ b/openapi/components/schemas/DelegationRuleCreateRequest.yaml
@@ -36,6 +36,7 @@ properties:
   processes:
     description: Process whitelist. Each entry is a process name covering every deployed version. Must contain at least one entry.
     type: array
+    minItems: 1
     items:
       type: string
 example:

--- a/openapi/components/schemas/DelegationRuleUpdateRequest.yaml
+++ b/openapi/components/schemas/DelegationRuleUpdateRequest.yaml
@@ -27,6 +27,7 @@ properties:
   processes:
     description: Process whitelist. Each entry is a process name covering every deployed version. Must contain at least one entry.
     type: array
+    minItems: 1
     items:
       type: string
 example:

--- a/openapi/components/schemas/DelegationRuleUpdateRequest.yaml
+++ b/openapi/components/schemas/DelegationRuleUpdateRequest.yaml
@@ -1,0 +1,37 @@
+type: object
+description: |
+  Body of `PUT /API/delegation/rule/{ruleId}`. Replaces the mutable fields of an existing
+  delegation rule. This is a full replacement, not a partial update: every field must be
+  provided on each call. The delegator of an existing rule cannot be changed.
+
+  The values must satisfy: `endDate` strictly after `startDate`, `delegateId` different from the
+  delegator, and a non-empty `processes` list. A violation is reported as `400`.
+required:
+  - delegateId
+  - startDate
+  - endDate
+  - processes
+properties:
+  delegateId:
+    description: Id of the user receiving access. Must differ from the delegator.
+    type: integer
+    format: int64
+  startDate:
+    description: Start of the delegation period, inclusive, in epoch milliseconds.
+    type: integer
+    format: int64
+  endDate:
+    description: End of the delegation period, inclusive, in epoch milliseconds. Must be strictly after `startDate`.
+    type: integer
+    format: int64
+  processes:
+    description: Process whitelist. Each entry is a process name covering every deployed version. Must contain at least one entry.
+    type: array
+    items:
+      type: string
+example:
+  delegateId: 2
+  startDate: 1780524000000
+  endDate: 1780696799999
+  processes:
+    - "Vacation request"

--- a/openapi/components/schemas/DelegationStatus.yaml
+++ b/openapi/components/schemas/DelegationStatus.yaml
@@ -1,0 +1,14 @@
+type: string
+description: |
+  Lifecycle status of a delegation rule, derived at query time from the rule's `startDate` /
+  `endDate` compared against the current time. There is no stored activation flag.
+
+  - `scheduled`: `startDate` is in the future. The delegate does not yet have access.
+  - `active`: the current time is within `[startDate, endDate]`. The delegate has access.
+  - `expired`: `endDate` is in the past. The delegate no longer has access.
+
+  Serialized in lowercase.
+enum:
+  - scheduled
+  - active
+  - expired

--- a/openapi/components/schemas/DelegationUser.yaml
+++ b/openapi/components/schemas/DelegationUser.yaml
@@ -1,0 +1,78 @@
+type: object
+description: |
+  User embedded in a delegation rule or a delegated task (delegator, delegate or last updater).
+
+  This is the engine `User` model serialized directly, so its field names (`userName`,
+  `managerUserId`, `creationDate`, ...) differ from the legacy snake_case `User` schema returned
+  by the `/API/identity/user` endpoints. The long id fields (`id`, `createdBy`, `managerUserId`)
+  are serialized as strings to avoid JavaScript precision loss, while the date fields
+  (`creationDate`, `lastUpdate`, `lastConnection`) are serialized as numeric epoch milliseconds.
+required:
+  - id
+  - userName
+  - firstName
+  - lastName
+  - enabled
+properties:
+  id:
+    description: User id. Serialized as a string to avoid JavaScript precision loss on large `long` values.
+    type: string
+  userName:
+    description: Login name of the user.
+    type: string
+  firstName:
+    description: First name of the user.
+    type: string
+    nullable: true
+  lastName:
+    description: Last name of the user.
+    type: string
+    nullable: true
+  title:
+    description: Civility title of the user.
+    type: string
+    nullable: true
+  jobTitle:
+    description: Job title of the user.
+    type: string
+    nullable: true
+  iconId:
+    description: Id of the icon row used as avatar, or `null` when no icon is set. Serialized as a string when present.
+    type: string
+    nullable: true
+  managerUserId:
+    description: Id of this user's manager, or `0` when none. Serialized as a string.
+    type: string
+  createdBy:
+    description: Id of the user who created this account (`-1` for system-created accounts). Serialized as a string.
+    type: string
+  creationDate:
+    description: Creation timestamp of the user account, in epoch milliseconds.
+    type: integer
+    format: int64
+  lastUpdate:
+    description: Last update timestamp of the user account, in epoch milliseconds.
+    type: integer
+    format: int64
+  lastConnection:
+    description: Last connection timestamp, in epoch milliseconds, or `null` if the user never logged in.
+    type: integer
+    format: int64
+    nullable: true
+  enabled:
+    description: Whether the user account is enabled.
+    type: boolean
+example:
+  id: "2"
+  firstName: "Michael"
+  lastName: "Scott"
+  userName: "michael.scott"
+  iconId: null
+  title: null
+  jobTitle: null
+  creationDate: 1780477806557
+  createdBy: "-1"
+  lastUpdate: 1780477806557
+  lastConnection: null
+  managerUserId: "0"
+  enabled: true

--- a/openapi/components/schemas/ProcessDeploymentInfo.yaml
+++ b/openapi/components/schemas/ProcessDeploymentInfo.yaml
@@ -1,8 +1,8 @@
 type: object
 description: |
-  Deployment information of a process, as embedded under the `rootProcessInfo` field of a
-  delegated task. It describes the process behind the root case that triggered the task, not
-  the child case the task may directly belong to.
+  Deployment information of a process: its name, version, activation and configuration state,
+  and deployment metadata. This is a general-purpose embedding shape, not delegation-specific;
+  it currently appears under the `rootProcessInfo` field of a delegated task.
 
   The internal deployment-info row id is intentionally not exposed; callers identify the process
   through `processId`. The `processId` and `deployedBy` long ids are serialized as strings to

--- a/openapi/components/schemas/ProcessDeploymentInfo.yaml
+++ b/openapi/components/schemas/ProcessDeploymentInfo.yaml
@@ -1,8 +1,8 @@
 type: object
 description: |
   Deployment information of a process, as embedded under the `rootProcessInfo` field of a
-  delegated task. It describes the root process whose deployment was started, even when the
-  task lives inside a subprocess.
+  delegated task. It describes the process behind the root case that triggered the task, not
+  the child case the task may directly belong to.
 
   The internal deployment-info row id is intentionally not exposed; callers identify the process
   through `processId`. The `processId` and `deployedBy` long ids are serialized as strings to
@@ -47,11 +47,11 @@ properties:
     type: integer
     format: int64
   activationState:
-    description: Activation state of the process (e.g. `ENABLED`, `DISABLED`).
-    type: string
+    description: Activation state of the process.
+    $ref: './ActivationState.yaml'
   configurationState:
-    description: Configuration state of the process (e.g. `RESOLVED`, `UNRESOLVED`).
-    type: string
+    description: Configuration state of the process.
+    $ref: './ConfigurationState.yaml'
   iconPath:
     description: Path to the process icon, or `null` when none is set.
     type: string

--- a/openapi/components/schemas/ProcessDeploymentInfo.yaml
+++ b/openapi/components/schemas/ProcessDeploymentInfo.yaml
@@ -1,0 +1,71 @@
+type: object
+description: |
+  Deployment information of a process, as embedded under the `rootProcessInfo` field of a
+  delegated task. It describes the root process whose deployment was started, even when the
+  task lives inside a subprocess.
+
+  The internal deployment-info row id is intentionally not exposed; callers identify the process
+  through `processId`. The `processId` and `deployedBy` long ids are serialized as strings to
+  avoid JavaScript precision loss, while date fields are serialized as numeric epoch milliseconds.
+required:
+  - processId
+  - name
+  - version
+  - activationState
+  - configurationState
+properties:
+  processId:
+    description: Identifier of the process definition. Serialized as a string to avoid JavaScript precision loss.
+    type: string
+  name:
+    description: Technical name of the process.
+    type: string
+  version:
+    description: Version of the process.
+    type: string
+  displayName:
+    description: Human-readable name of the process.
+    type: string
+    nullable: true
+  description:
+    description: Description of the process.
+    type: string
+    nullable: true
+  displayDescription:
+    description: Human-readable description of the process.
+    type: string
+    nullable: true
+  deploymentDate:
+    description: Deployment timestamp of the process, in epoch milliseconds.
+    type: integer
+    format: int64
+  deployedBy:
+    description: Id of the user who deployed the process. Serialized as a string.
+    type: string
+  lastUpdateDate:
+    description: Timestamp of the last update of the deployment information, in epoch milliseconds.
+    type: integer
+    format: int64
+  activationState:
+    description: Activation state of the process (e.g. `ENABLED`, `DISABLED`).
+    type: string
+  configurationState:
+    description: Configuration state of the process (e.g. `RESOLVED`, `UNRESOLVED`).
+    type: string
+  iconPath:
+    description: Path to the process icon, or `null` when none is set.
+    type: string
+    nullable: true
+example:
+  name: "Vacation request"
+  version: "1.0"
+  displayDescription: ""
+  deploymentDate: 1780576273140
+  deployedBy: "1"
+  configurationState: "RESOLVED"
+  activationState: "ENABLED"
+  processId: "5270206374128493046"
+  displayName: "Vacation request"
+  lastUpdateDate: 1780576574182
+  iconPath: null
+  description: ""

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -269,6 +269,10 @@ tags:
     description: |
       Delegate human tasks from one user (the delegator) to another (the delegate) for a bounded period and a whitelist of processes. Delegation grants the delegate visibility and execution rights on the delegator's tasks without reassigning them: ownership and the audit trail are preserved. A user can hold at most one delegation rule at a time, and a rule's status (scheduled, active, expired) is derived from its date range.
 
+      Id fields are sent as numeric `int64` in request bodies but returned as strings in responses, to avoid JavaScript precision loss on large `long` values; this is intentional and documented per field.
+
+      There is no `GET /API/delegation/rule/{ruleId}`: the engine does not expose a single-rule read, so fetch a rule through the search endpoint (`GET /API/delegation/rule`) filtered by `id`. This is a known API gap, not a spec omission.
+
       This Web REST API is available in **Enterprise editions only**, since version 2026.2.
   - name: Diagram
     x-displayName: Diagram

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -80,6 +80,7 @@ x-tagGroups:
       - TimerEventTrigger
       - Message
       - Signal
+      - Delegation
 
   - name: Custom user info
     tags:
@@ -263,6 +264,12 @@ tags:
       Configure how Bonita automatically deletes obsolete business data. A retention rule applies to a specific business object type and defines when its instances become eligible for deletion based on a reference date (creation or last update) and a retention period in days. The data retention service runs on a configurable cron schedule.
 
       This Web REST API is available in **Enterprise editions only**, since version 11.0.
+  - name: Delegation
+    x-displayName: Delegation
+    description: |
+      Delegate human tasks from one user (the delegator) to another (the delegate) for a bounded period and a whitelist of processes. Delegation grants the delegate visibility and execution rights on the delegator's tasks without reassigning them: ownership and the audit trail are preserved. A user can hold at most one delegation rule at a time, and a rule's status (scheduled, active, expired) is derived from its date range.
+
+      This Web REST API is available in **Enterprise editions only**, since version 2026.2.
   - name: Diagram
     x-displayName: Diagram
     description: Diagram
@@ -447,6 +454,15 @@ paths:
     $ref: './paths/API@retention@rule.yaml'
   '/API/retention/rule/{ruleId}':
     $ref: './paths/API@retention@rule@{ruleId}.yaml'
+  #  =======================
+  #   DELEGATION API
+  #  =======================
+  /API/delegation/rule:
+    $ref: './paths/API@delegation@rule.yaml'
+  '/API/delegation/rule/{ruleId}':
+    $ref: './paths/API@delegation@rule@{ruleId}.yaml'
+  /API/delegation/task:
+    $ref: './paths/API@delegation@task.yaml'
   #  =======================
   #   BPM API
   #  =======================

--- a/openapi/paths/API@delegation@rule.yaml
+++ b/openapi/paths/API@delegation@rule.yaml
@@ -45,7 +45,7 @@ get:
 post:
   tags:
     - Delegation
-  summary: Create a delegation rule
+  summary: Create or replace a delegation rule
   description: |
     ![edition](https://img.shields.io/badge/edition-entreprise-blue)
 

--- a/openapi/paths/API@delegation@rule.yaml
+++ b/openapi/paths/API@delegation@rule.yaml
@@ -1,0 +1,81 @@
+get:
+  tags:
+    - Delegation
+  summary: Search delegation rules
+  description: |
+    ![edition](https://img.shields.io/badge/edition-entreprise-blue)
+
+    Searches delegation rules with pagination and filters. The same endpoint serves regular users
+    (who see their own rule) and administrators (who see rules across users); authorization is
+    enforced by the engine.
+
+    - can order on `id`, `delegatorId`, `delegateId`, `startDate`, `endDate`, `lastUpdatedBy`, `lastUpdatedAt`
+    - can filter on `id`, `delegatorId`, `delegateId`, `startDate`, `endDate`, `lastUpdatedBy`, `lastUpdatedAt` and on `status` (a virtual filter accepting `scheduled`, `active` or `expired`)
+    - the free-text search term (`s`) is matched by the engine against the delegator and delegate user name, first name and last name
+
+    Available in Enterprise editions only, since Bonita 2026.2.
+  operationId: searchDelegationRules
+  parameters:
+    - $ref: '../components/parameters/pageIndex.yaml'
+    - $ref: '../components/parameters/pageCount.yaml'
+    - $ref: '../components/parameters/pageFilter.yaml'
+    - $ref: '../components/parameters/pageOrder.yaml'
+    - $ref: '../components/parameters/pageSearch.yaml'
+  responses:
+    '200':
+      description: Successful operation
+      headers:
+        Content-Range:
+          schema:
+            type: integer
+            format: int64
+          description: The total number of matching items
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '../components/schemas/DelegationRule.yaml'
+    '401':
+      $ref: '../components/responses/Unauthorized.yaml'
+    '403':
+      $ref: '../components/responses/Forbidden.yaml'
+    '5XX':
+      $ref: '../components/responses/ServerError.yaml'
+post:
+  tags:
+    - Delegation
+  summary: Create a delegation rule
+  description: |
+    ![edition](https://img.shields.io/badge/edition-entreprise-blue)
+
+    Creates a delegation rule. `delegatorId` is optional and resolved from the session when
+    omitted (self-service); administrators may set it to create a rule on behalf of another user.
+
+    A user can hold at most one delegation rule: posting a rule for a delegator who already has
+    one replaces the existing rule (upsert).
+
+    Available in Enterprise editions only, since Bonita 2026.2.
+  operationId: createDelegationRule
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../components/schemas/DelegationRuleCreateRequest.yaml'
+  responses:
+    '201':
+      description: Delegation rule created
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/DelegationRule.yaml'
+    '400':
+      $ref: '../components/responses/BadRequest.yaml'
+    '401':
+      $ref: '../components/responses/Unauthorized.yaml'
+    '403':
+      $ref: '../components/responses/Forbidden.yaml'
+    '5XX':
+      $ref: '../components/responses/ServerError.yaml'
+  x-codegen-request-body-name: body

--- a/openapi/paths/API@delegation@rule@{ruleId}.yaml
+++ b/openapi/paths/API@delegation@rule@{ruleId}.yaml
@@ -1,0 +1,74 @@
+put:
+  tags:
+    - Delegation
+  summary: Update a delegation rule by ID
+  description: |
+    ![edition](https://img.shields.io/badge/edition-entreprise-blue)
+
+    Replaces the `delegateId`, `startDate`, `endDate` and `processes` of an existing delegation
+    rule. The delegator of the rule cannot be changed.
+
+    Available in Enterprise editions only, since Bonita 2026.2.
+  operationId: updateDelegationRuleById
+  parameters:
+    - description: Numeric ID of the delegation rule to update (the `id` field returned by `DelegationRule`).
+      in: path
+      name: ruleId
+      required: true
+      schema:
+        type: string
+        pattern: '^[0-9]+$'
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          $ref: '../components/schemas/DelegationRuleUpdateRequest.yaml'
+  responses:
+    '200':
+      description: Delegation rule updated
+      content:
+        application/json:
+          schema:
+            $ref: '../components/schemas/DelegationRule.yaml'
+    '400':
+      $ref: '../components/responses/BadRequest.yaml'
+    '401':
+      $ref: '../components/responses/Unauthorized.yaml'
+    '403':
+      $ref: '../components/responses/Forbidden.yaml'
+    '404':
+      $ref: '../components/responses/NotFound.yaml'
+    '5XX':
+      $ref: '../components/responses/ServerError.yaml'
+  x-codegen-request-body-name: body
+delete:
+  tags:
+    - Delegation
+  summary: Delete a delegation rule by ID
+  description: |
+    ![edition](https://img.shields.io/badge/edition-entreprise-blue)
+
+    Deletes the delegation rule with the given ID. This is the only deactivation mechanism: there
+    is no soft delete or activation flag. Deleting a rule does not affect the underlying tasks,
+    which remain assigned to the delegator.
+
+    Available in Enterprise editions only, since Bonita 2026.2.
+  operationId: deleteDelegationRuleById
+  parameters:
+    - description: Numeric ID of the delegation rule to delete (the `id` field returned by `DelegationRule`).
+      in: path
+      name: ruleId
+      required: true
+      schema:
+        type: string
+        pattern: '^[0-9]+$'
+  responses:
+    '204':
+      $ref: '../components/responses/NoContent.yaml'
+    '401':
+      $ref: '../components/responses/Unauthorized.yaml'
+    '403':
+      $ref: '../components/responses/Forbidden.yaml'
+    '5XX':
+      $ref: '../components/responses/ServerError.yaml'

--- a/openapi/paths/API@delegation@task.yaml
+++ b/openapi/paths/API@delegation@task.yaml
@@ -5,14 +5,14 @@ get:
   description: |
     ![edition](https://img.shields.io/badge/edition-entreprise-blue)
 
-    Searches the human tasks the current user can act on through an active delegation rule. Only
+    Searches the human tasks a user can act on through an active delegation rule. Only
     tasks covered by an `active` rule are returned: scheduled and expired rules yield nothing.
-    Tasks remain assigned to the delegator; the delegate gains visibility and execution rights
+    Tasks should be assigned to the delegator and remain assigned to them; the delegate gains visibility and execution rights
     without reassignment.
 
     - can order on `dueDate`, `priority`, `reachedStateDate`
     - can search (`s`) on the task name and display name
-    - can filter on `delegateId` (must be numeric; scopes results to a delegate, enforced against the session user unless the caller is an administrator) and on `rootProcessName` (narrows results to a specific root process)
+    - can filter on `delegateId` (must be numeric; scopes results to a delegate, enforced against the session user by (dynamic) authorization rules unless the caller is an administrator) and on `rootProcessName` (narrows results to a specific root process)
 
     Available in Enterprise editions only, since Bonita 2026.2.
   operationId: searchDelegatedTasks

--- a/openapi/paths/API@delegation@task.yaml
+++ b/openapi/paths/API@delegation@task.yaml
@@ -1,0 +1,47 @@
+get:
+  tags:
+    - Delegation
+  summary: Search delegated tasks
+  description: |
+    ![edition](https://img.shields.io/badge/edition-entreprise-blue)
+
+    Searches the human tasks the current user can act on through an active delegation rule. Only
+    tasks covered by an `active` rule are returned: scheduled and expired rules yield nothing.
+    Tasks remain assigned to the delegator; the delegate gains visibility and execution rights
+    without reassignment.
+
+    - can order on `dueDate`, `priority`, `reachedStateDate`
+    - can search (`s`) on the task name and display name
+    - can filter on `delegateId` (must be numeric; scopes results to a delegate, enforced against the session user unless the caller is an administrator) and on `rootProcessName` (narrows results to a specific root process)
+
+    Available in Enterprise editions only, since Bonita 2026.2.
+  operationId: searchDelegatedTasks
+  parameters:
+    - $ref: '../components/parameters/pageIndex.yaml'
+    - $ref: '../components/parameters/pageCount.yaml'
+    - $ref: '../components/parameters/pageFilter.yaml'
+    - $ref: '../components/parameters/pageOrder.yaml'
+    - $ref: '../components/parameters/pageSearch.yaml'
+  responses:
+    '200':
+      description: Successful operation
+      headers:
+        Content-Range:
+          schema:
+            type: integer
+            format: int64
+          description: The total number of matching items
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '../components/schemas/DelegatedTask.yaml'
+    '400':
+      $ref: '../components/responses/BadRequest.yaml'
+    '401':
+      $ref: '../components/responses/Unauthorized.yaml'
+    '403':
+      $ref: '../components/responses/Forbidden.yaml'
+    '5XX':
+      $ref: '../components/responses/ServerError.yaml'


### PR DESCRIPTION
## Summary

Document the **task delegation** REST API used by the delegation administration and self-service applications ([BPA-588](https://bonitasoft.atlassian.net/browse/BPA-588)):

- `GET /API/delegation/rule` - search delegation rules (pagination, filters, free-text on delegator/delegate names)
- `POST /API/delegation/rule` - create a delegation rule (`delegatorId` optional, resolved from the session for self-service)
- `PUT /API/delegation/rule/{ruleId}` - update `delegateId` / `startDate` / `endDate` / `processes` of an existing rule
- `DELETE /API/delegation/rule/{ruleId}` - delete a rule
- `GET /API/delegation/task` - search the human tasks the caller can act on through an active rule

Adds the supporting schemas under `openapi/components/schemas/`:

- Response: `DelegationRule`, `DelegatedTask`, `DelegationUser`, `ProcessDeploymentInfo`, `DelegationStatus`
- Request: `DelegationRuleCreateRequest`, `DelegationRuleUpdateRequest`

A new `Delegation` tag is registered under the existing **BPM** tag group.

Available in Enterprise editions only, since Bonita 2026.2.

Schemas were derived from the engine source (`com.bonitasoft.web.rest.server.api.delegation.DelegationRuleController` / `DelegatedTaskController`, the `DelegationRuleRequest` DTO, and the `DelegationRule` / `DelegatedTask` / `DelegationStatus` model types) and validated against the live runtime at `http://localhost:8080/bonita` via the existing demo data and a set of POST/PUT/DELETE probes.

### Notes

- **Two different `User` serializations.** The delegator/delegate/lastUpdatedBy embedded users use the engine `User` model serialized directly (camelCase `userName`, `managerUserId`, `creationDate`, ...), which differs from the legacy snake_case `User` schema returned by `/API/identity/user`. Hence the dedicated `DelegationUser` schema. Within it, long ids (`id`, `createdBy`, `managerUserId`, `iconId`) are strings while date fields (`creationDate`, `lastUpdate`, `lastConnection`) are numeric epoch millis - as are the rule's own `startDate` / `endDate` / `lastUpdatedAt`. This split mirrors the engine output and is documented in the field descriptions.
- **`POST` is an upsert, not a create-or-conflict.** A user can hold at most one delegation rule; posting a second rule for the same delegator replaces the existing one. There is therefore no `409` (unlike the data-retention API).
- **`DELETE` of a non-existent rule currently returns `5XX`, not `404`.** The controller's `@ExceptionHandler` maps `CreationException` / `UpdateException` to `400` but not `DeletionException`, so a missing-id delete falls through to the generic handler. `PUT` keeps `404` because `NotFoundException` is mapped. Documented faithfully: `DELETE` declares `204/401/403/5XX`.
- **`GET /API/delegation/rule` has no documented `400`.** An unknown filter key surfaces as `5XX` (`BonitaRuntimeException`) rather than `400` on the current build, so the search operation declares `200/401/403/5XX`. `GET /API/delegation/task` keeps `400` because a non-numeric `delegateId` filter is validated up front and returns `400`.
- **Bean validation is documentation-only.** The `@NotNull` / `@NotEmpty` / `@AssertTrue` annotations on `DelegationRuleRequest` do not fire yet (no Bean Validation provider wired); the controller hand-rolls the null checks and the engine enforces the cross-field rules, all surfacing as `400`. The spec documents the intended `400`.
- **Internal `humanTaskInstance` delegate is excluded.** `DelegatedTaskImpl` wraps a `HumanTaskInstance` it forwards to; the Lombok `@Data` getter would otherwise serialize it as a redundant nested object carrying the raw engine model with **numeric** long ids, bypassing the string-id contract. It is hidden engine-side with `@JsonIgnore` on the `humanTaskInstance` field (guarded by `DelegatedTaskImplJsonSerializationTest`) and is intentionally absent from the `DelegatedTask` schema. Tracked as [BPA-589](https://bonitasoft.atlassian.net/browse/BPA-589) / [bonita-engine-sp#3926](https://github.com/bonitasoft/bonita-engine-sp/pull/3926).

## Test plan

- [x] `npm test` passes (only the 2 pre-existing warnings unrelated to this PR: localhost server url, regex in `API@living@application.yaml`)
- [x] `npm run yaml` bundles cleanly into `dist/openapi.yaml`
- [x] Live `GET /API/delegation/rule` matches the documented `DelegationRule` shape (string-encoded ids, numeric epoch-millis dates, lowercase `status`, embedded `DelegationUser`, `Content-Range` header)
- [x] Live `GET /API/delegation/task` matches the documented `DelegatedTask` shape (HumanTaskItem-aligned camelCase keys, `rootProcessInfo`, delegation window)
- [x] Live `POST` bad input (delegate == delegator, missing `delegateId`, inverted dates) returns `400`
- [x] Live `PUT` on an unknown id returns `404`
- [x] Live `DELETE` on an unknown id returns `5XX` (documented accordingly)
- [x] Live unauthenticated request returns `401`

[BPA-588]: https://bonitasoft.atlassian.net/browse/BPA-588?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


[BPA-589]: https://bonitasoft.atlassian.net/browse/BPA-589?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
