### PR TITLE
docs(bpm): document GET /API/bpm/processName grouped process-name search

### DIFF
--- a/openapi/components/schemas/ProcessName.yaml
+++ b/openapi/components/schemas/ProcessName.yaml
@@ -12,9 +12,8 @@ properties:
     description: Technical name shared by every version in this group.
     type: string
   displayName:
-    description: Human-readable name shared by every version in this group. May be `null` when the processes have no display name set.
+    description: Human-readable name shared by every version in this group. Defaults to the process technical name when no display name was set at deployment.
     type: string
-    nullable: true
   versions:
     description: |
       Deployed versions of the process sharing this name and display name. When an `activationState`

--- a/openapi/components/schemas/ProcessName.yaml
+++ b/openapi/components/schemas/ProcessName.yaml
@@ -1,0 +1,32 @@
+type: object
+description: |
+  A group of deployed processes that share the same `(name, displayName)` pair, with the list of
+  their deployed versions. Returned by `GET /API/bpm/processName`, which collapses the process
+  deployment information into one entry per distinct name and display name.
+required:
+  - name
+  - displayName
+  - versions
+properties:
+  name:
+    description: Technical name shared by every version in this group.
+    type: string
+  displayName:
+    description: Human-readable name shared by every version in this group. May be `null` when the processes have no display name set.
+    type: string
+    nullable: true
+  versions:
+    description: |
+      Deployed versions of the process sharing this name and display name. When an `activationState`
+      filter is supplied, only the versions in that state are listed. Always contains at least one entry.
+    type: array
+    minItems: 1
+    items:
+      type: string
+example:
+  name: "InvoiceApproval"
+  displayName: "Invoice Approval"
+  versions:
+    - "1.0"
+    - "1.1"
+    - "2.0"

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -572,6 +572,8 @@ paths:
     $ref: './paths/API@bpm@process@{id}@contract.yaml'
   /API/bpm/process/{id}/instantiation:
     $ref: './paths/API@bpm@process@{id}@instantiation.yaml'
+  /API/bpm/processName:
+    $ref: './paths/API@bpm@processName.yaml'
   /API/bpm/processInfo/{id}:
     $ref: './paths/API@bpm@processInfo@{id}.yaml'
   /API/bpm/processConnector/{id}/{connectorImplId}/{connectorImplVersion}:

--- a/openapi/paths/API@bpm@processName.yaml
+++ b/openapi/paths/API@bpm@processName.yaml
@@ -37,11 +37,11 @@ get:
             type: array
             items:
               $ref: '../components/schemas/ProcessName.yaml'
-    '400':
-      $ref: '../components/responses/BadRequest.yaml'
     '401':
       $ref: '../components/responses/Unauthorized.yaml'
     '403':
       $ref: '../components/responses/Forbidden.yaml'
+    '400':
+      $ref: '../components/responses/BadRequest.yaml'
     '5XX':
       $ref: '../components/responses/ServerError.yaml'

--- a/openapi/paths/API@bpm@processName.yaml
+++ b/openapi/paths/API@bpm@processName.yaml
@@ -1,0 +1,47 @@
+get:
+  tags:
+    - Process
+  summary: Search process names
+  description: |
+    Searches process deployment information grouped by `(name, displayName)`, returning one entry per
+    distinct name and display name, each carrying the list of its deployed versions.
+
+    - can order on `displayName` or `name` (default is `displayName ASC`). A single sort clause is
+      applied: a compound order such as `displayName ASC, name DESC` is rejected with a `400`.
+    - can search (`s`) on `name`, `displayName` or `version`. The term selects which groups are
+      returned; it is not applied per version, so a returned group lists all of its versions allowed
+      by the `activationState` filter, even those that did not individually match the term.
+    - can filter on `activationState` with the value `ENABLED` or `DISABLED`. An unknown value is
+      rejected with a `400`; other filter keys are ignored.
+
+    The `Content-Range` header reports the total number of groups, not the number of versions.
+  operationId: searchProcessNames
+  parameters:
+    - $ref: '../components/parameters/pageIndex.yaml'
+    - $ref: '../components/parameters/pageCount.yaml'
+    - $ref: '../components/parameters/pageFilter.yaml'
+    - $ref: '../components/parameters/pageOrder.yaml'
+    - $ref: '../components/parameters/pageSearch.yaml'
+  responses:
+    '200':
+      description: Successful operation
+      headers:
+        Content-Range:
+          schema:
+            type: integer
+            format: int64
+          description: The total number of matching groups
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '../components/schemas/ProcessName.yaml'
+    '400':
+      $ref: '../components/responses/BadRequest.yaml'
+    '401':
+      $ref: '../components/responses/Unauthorized.yaml'
+    '403':
+      $ref: '../components/responses/Forbidden.yaml'
+    '5XX':
+      $ref: '../components/responses/ServerError.yaml'

--- a/openapi/paths/API@bpm@processName.yaml
+++ b/openapi/paths/API@bpm@processName.yaml
@@ -8,9 +8,8 @@ get:
 
     - can order on `displayName` or `name` (default is `displayName ASC`). A single sort clause is
       applied: a compound order such as `displayName ASC, name DESC` is rejected with a `400`.
-    - can search (`s`) on `name`, `displayName` or `version`. The term selects which groups are
-      returned; it is not applied per version, so a returned group lists all of its versions allowed
-      by the `activationState` filter, even those that did not individually match the term.
+    - can search (`s`) on `name` or `displayName`. The term selects which groups are returned; a
+      returned group always lists all of its versions allowed by the `activationState` filter.
     - can filter on `activationState` with the value `ENABLED` or `DISABLED`. An unknown value is
       rejected with a `400`; other filter keys are ignored.
 


### PR DESCRIPTION
## Summary

Documents the new read-only REST endpoint **`GET /API/bpm/processName`** introduced in [bonitasoft/bonita-engine-sp#3937](https://github.com/bonitasoft/bonita-engine-sp/pull/3937) ([BPA-599](https://bonitasoft.atlassian.net/browse/BPA-599)).

The endpoint searches process deployment information grouped by `(name, displayName)`, returning one entry per distinct name and display name, each carrying the list of its deployed versions.

## What's included

- **`components/schemas/ProcessName.yaml`** - the group shape: `name`, `displayName`, and a non-empty `versions` array.
- **`paths/API@bpm@processName.yaml`** - search-only `GET` under the `Process` tag (`operationId: searchProcessNames`), with the five pagination parameters, a `200` array response, and a `Content-Range` header whose total counts groups (not versions).
- **`openapi.yaml`** - registers the path under the BPM section.

## Contract documented (from the engine controller)

- Ordering restricted to `displayName` / `name`, a single clause, default `displayName ASC`; a compound order is rejected with `400`.
- Free-text search (`s`) matches `name` or `displayName`; it selects which groups are returned but does not filter the per-group version list.
- Filtering limited to `activationState` (`ENABLED` / `DISABLED`); an unknown value is rejected with `400`; other filter keys are ignored.

## Validation

`npm test` (redocly lint) passes; no new warnings.

## Notes

- No enterprise edition badge: the backing controller ships in the community `bonita-web-server`.
- `displayName` is `required` and always present; the engine defaults it to the process technical name at deployment when none is set (`ProcessDefinitionServiceImpl#createProcessDefinitionDeployInfo`), so it is never null.

[BPA-599]: https://bonitasoft.atlassian.net/browse/BPA-599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
