### PR TITLE
docs(identity): document GET /API/identity/userSummary resource

### DIFF
--- a/openapi/components/schemas/UserSummary.yaml
+++ b/openapi/components/schemas/UserSummary.yaml
@@ -1,0 +1,26 @@
+type: object
+description: |
+  Lightweight projection of a User returned by the `identity/userSummary` resource:
+  only the id, user name, first name, last name and job title.
+properties:
+  id:
+    description: user id
+    type: string
+  userName:
+    description: user name
+    type: string
+  firstName:
+    description: user first name
+    type: string
+  lastName:
+    description: user last name
+    type: string
+  jobTitle:
+    description: user job title. Optional on a user, `null` when unset.
+    type: string
+    nullable: true
+required:
+  - id
+  - userName
+  - firstName
+  - lastName

--- a/openapi/components/schemas/UserSummary.yaml
+++ b/openapi/components/schemas/UserSummary.yaml
@@ -2,6 +2,8 @@ type: object
 description: |
   Lightweight projection of a User returned by the `identity/userSummary` resource:
   only the id, user name, first name, last name and job title.
+
+  Attribute names are kept consistent with the `identity/user` resource.
 properties:
   id:
     description: user id
@@ -9,18 +11,18 @@ properties:
   userName:
     description: user name
     type: string
-  firstName:
+  firstname:
     description: user first name
     type: string
-  lastName:
+  lastname:
     description: user last name
     type: string
-  jobTitle:
+  job_title:
     description: user job title. Optional on a user, `null` when unset.
     type: string
     nullable: true
 required:
   - id
   - userName
-  - firstName
-  - lastName
+  - firstname
+  - lastname

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -667,6 +667,8 @@ paths:
     $ref: './paths/API@identity@user.yaml'
   /API/identity/user/{id}:
     $ref: './paths/API@identity@user@{id}.yaml'
+  /API/identity/userSummary:
+    $ref: './paths/API@identity@userSummary.yaml'
 
   #  =======================
   #   PLATFORM API

--- a/openapi/paths/API@identity@userSummary.yaml
+++ b/openapi/paths/API@identity@userSummary.yaml
@@ -3,7 +3,7 @@ get:
     - User
   summary: Finds User summaries
   description: |
-    Finds a paginated, lightweight projection of users (`id`, `userName`, `firstName`, `lastName`, `jobTitle`),
+    Finds a paginated, lightweight projection of users (`id`, `userName`, `firstname`, `lastname`, `job_title`),
     intended for user pickers and similar listings without exposing the full `identity/user` payload.
 
     - `p` / `c`: pagination params (page index and page size)

--- a/openapi/paths/API@identity@userSummary.yaml
+++ b/openapi/paths/API@identity@userSummary.yaml
@@ -1,0 +1,46 @@
+get:
+  tags:
+    - User
+  summary: Finds User summaries
+  description: |
+    Finds a paginated, lightweight projection of users (`id`, `userName`, `firstName`, `lastName`, `jobTitle`),
+    intended for user pickers and similar listings without exposing the full `identity/user` payload.
+
+    - `p` / `c`: pagination params (page index and page size)
+    - can search (`s`) on a free-text term matched by the engine across user attributes
+    - can order (`o`) on `username` (default `username ASC`), `firstname` or `lastname`. One or more
+      comma-separated sort clauses are applied in order (e.g. `lastname,firstname`). An optional `ASC` or
+      `DESC` direction may follow each field. Unknown fields or malformed clauses return `400`.
+    - can filter (`f`) only on `enabled` with a boolean value (e.g. `enabled=true`). Any other filter key
+      or a non-boolean value returns `400`. `enabled` is filter-only and is not part of the returned projection.
+
+  operationId: searchUserSummaries
+  parameters:
+    - $ref: '../components/parameters/pageIndex.yaml'
+    - $ref: '../components/parameters/pageCount.yaml'
+    - $ref: '../components/parameters/pageFilter.yaml'
+    - $ref: '../components/parameters/pageOrder.yaml'
+    - $ref: '../components/parameters/pageSearch.yaml'
+  responses:
+    '200':
+      description: "Success "
+      headers:
+        Content-Range:
+          schema:
+            type: integer
+            format: int64
+          description: The total number of matching items
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: '../components/schemas/UserSummary.yaml'
+    '401':
+      $ref: '../components/responses/Unauthorized.yaml'
+    '403':
+      $ref: '../components/responses/Forbidden.yaml'
+    '400':
+      $ref: '../components/responses/BadRequest.yaml'
+    '5XX':
+      $ref: '../components/responses/ServerError.yaml'


### PR DESCRIPTION
## What

Documents the new `GET /API/identity/userSummary` REST resource (bonita-engine-sp #3938) in the OpenAPI spec. It returns a lightweight, paginated projection of users (`id`, `userName`, `firstname`, `lastname`, `job_title`), intended for user pickers and similar listings without exposing the full `identity/user` payload.

## Changes

- **`openapi/components/schemas/UserSummary.yaml`** (new) - the response item schema. Attribute names are kept consistent with the existing `identity/user` resource: `id`, `userName`, `firstname`, `lastname`, `job_title`. `job_title` is nullable; `id`, `userName`, `firstname` and `lastname` are required.
- **`openapi/paths/API@identity@userSummary.yaml`** (new) - the `GET` operation (`searchUserSummaries`), reusing the shared pagination parameters. Documents:
  - free-text search (`s`)
  - sort (`o`) on `username` (default `username ASC`), `firstname` or `lastname`, comma-separated clauses applied in order, with optional `ASC`/`DESC`; unknown fields or malformed clauses return `400`
  - filter (`f`) limited to `enabled` (boolean); any other key or a non-boolean value returns `400`
  - `Content-Range` header with the total count
- **`openapi/openapi.yaml`** - register the path under the IDENTITY section, reusing the existing `User` tag.

## Verification

- `npm test` (redocly lint) passes; the only warnings are pre-existing and unrelated to these files.

## Reference

- Engine resource: bonitasoft/bonita-engine-sp#3938
